### PR TITLE
Clades storage

### DIFF
--- a/include/larch/compute.hpp
+++ b/include/larch/compute.hpp
@@ -164,10 +164,33 @@ inline bool is_leaf(phylo_dag& d, std::size_t node_idx) {
       nv);
 }
 
+// Build CSR-style clade offsets for all nodes.
+// Must be called after all edges have their clade_index set and before
+// get_clades() is used in performance-critical paths.
+inline void build_clade_offsets(phylo_dag& d) {
+  d.build_all_clade_offsets([&d](std::size_t edge_idx) -> std::size_t {
+    return d.get_edge_as<edge_kind::clade>(edge_idx).clade_index();
+  });
+}
+
 // Groups a node's child edges by clade_index.
 // Returns vector where result[i] = edge indices for clade i.
+// When clade offsets have been built via build_clade_offsets(), this reads
+// directly from the pre-sorted children section (no annotation lookups).
 inline auto get_clades(phylo_dag& d, std::size_t node_idx)
     -> std::vector<std::vector<std::size_t>> {
+  auto nc = d.clade_count(node_idx);
+  if (nc > 0) {
+    // Fast path: read from CSR clade offsets
+    std::vector<std::vector<std::size_t>> clades(nc);
+    for (std::size_t ci = 0; ci < nc; ++ci) {
+      auto sec = d.clade_section(node_idx, ci);
+      clades[ci].reserve(sec.size());
+      for (auto edge_idx : sec) clades[ci].push_back(edge_idx);
+    }
+    return clades;
+  }
+  // Slow path: scan edge annotations
   std::vector<std::vector<std::size_t>> clades;
   auto nv = d.get_node(node_idx);
   std::visit(
@@ -189,6 +212,19 @@ inline auto get_clades(phylo_dag& d, std::size_t node_idx)
 inline auto get_clades(phylo_dag& d, std::size_t node_idx,
                        std::pmr::memory_resource* mr)
     -> std::pmr::vector<std::pmr::vector<std::size_t>> {
+  auto nc = d.clade_count(node_idx);
+  if (nc > 0) {
+    // Fast path: read from CSR clade offsets
+    std::pmr::vector<std::pmr::vector<std::size_t>> clades(mr);
+    clades.resize(nc, std::pmr::vector<std::size_t>(mr));
+    for (std::size_t ci = 0; ci < nc; ++ci) {
+      auto sec = d.clade_section(node_idx, ci);
+      clades[ci].reserve(sec.size());
+      for (auto edge_idx : sec) clades[ci].push_back(edge_idx);
+    }
+    return clades;
+  }
+  // Slow path: scan edge annotations
   std::pmr::vector<std::pmr::vector<std::size_t>> clades(mr);
   auto nv = d.get_node(node_idx);
   std::visit(

--- a/include/larch/dag.hpp
+++ b/include/larch/dag.hpp
@@ -4,6 +4,8 @@
 #include <larch/common.hpp>
 #include <larch/chain.hpp>
 
+#include <algorithm>
+#include <cassert>
 #include <concepts>
 #include <optional>
 #include <ranges>
@@ -110,6 +112,8 @@ struct node_topology {
   std::size_t parents_count_;
   std::size_t children_start_;
   std::size_t children_count_;
+  std::size_t clade_offsets_start_ = no_idx;  // index into clade_offsets_ chain
+  std::size_t clade_count_ = 0;               // number of clades (offsets has count+1 entries)
   std::size_t annotation_index_;
 };
 
@@ -144,6 +148,8 @@ class node_view : public interface<V> {
   auto append_parent();
   auto get_children();
   auto get_parents();
+  auto get_clade(std::size_t clade_i);
+  std::size_t clade_count() const;
   void remove();
   std::size_t index() const { return index_; }
 
@@ -265,6 +271,11 @@ class dag_interface {
   auto get_edge(this auto& self, std::size_t idx) {
     return self.make_edge_variant(idx);
   }
+  template <auto V>
+  auto get_edge_as(this auto& self, std::size_t idx) {
+    using Self = std::remove_reference_t<decltype(self)>;
+    return edge_view<Self, V>{self, idx};
+  }
 
   std::size_t node_count(this auto& self) { return self.s_node_topos().size(); }
   std::size_t edge_count(this auto& self) { return self.s_edge_topos().size(); }
@@ -273,6 +284,27 @@ class dag_interface {
   }
   std::size_t edge_high_mark(this auto const& self) {
     return self.s_edge_high_mark();
+  }
+
+  // --- Clade-grouped children (CSR offsets into children section) ---
+
+  // Number of clades for this node (0 if offsets not built).
+  std::size_t clade_count(this auto const& self, std::size_t node_idx) {
+    return self.s_clade_count(node_idx);
+  }
+
+  // Contiguous section of edge indices for one clade.
+  // Requires clade offsets to have been built (clade_count > 0).
+  auto clade_section(this auto& self, std::size_t node_idx,
+                     std::size_t clade_i) {
+    return self.s_clade_section(node_idx, clade_i);
+  }
+
+  // Build CSR-style clade offsets for all nodes.
+  // F is called as get_edge_clade_idx(edge_idx) -> std::size_t.
+  template <typename F>
+  void build_all_clade_offsets(this auto& self, F&& get_edge_clade_idx) {
+    self.s_build_all_clade_offsets(std::forward<F>(get_edge_clade_idx));
   }
 
  private:
@@ -352,7 +384,10 @@ class dag_interface {
                          std::size_t count) {
     self.s_dealloc_neighbors(start, count);
   }
-
+  void dealloc_clade_offsets(this auto& self, std::size_t start,
+                             std::size_t count) {
+    self.s_dealloc_clade_offsets(start, count);
+  }
   // Factory for typed views (used by edge_view::get_child_as / get_parent_as)
   template <auto V>
   auto make_typed_node_view(this auto& self, std::size_t idx) {
@@ -415,6 +450,7 @@ class dag : public dag_interface<N, E> {
  private:
   index_type root_ = no_idx;
   chain<std::size_t> neighbors_;
+  chain<std::size_t> clade_offsets_;
   chain<node_topology<N>> node_topologies_;
   chain<edge_topology<E>> edge_topologies_;
   detail::annotation_tuple_from<node_enumerators> node_annotations_;
@@ -467,8 +503,76 @@ class dag : public dag_interface<N, E> {
         neighbors_, ntopo.parents_start_, ntopo.parents_count_};
   }
 
+  auto s_clade_section(std::size_t node_idx, std::size_t clade_i) {
+    auto& ntopo = node_topologies_[node_idx];
+    assert(ntopo.clade_count_ > 0 && clade_i < ntopo.clade_count_);
+    auto start_off = clade_offsets_[ntopo.clade_offsets_start_ + clade_i];
+    auto end_off = clade_offsets_[ntopo.clade_offsets_start_ + clade_i + 1];
+    return typename chain<std::size_t>::contiguous_section{
+        neighbors_, ntopo.children_start_ + start_off, end_off - start_off};
+  }
+
+  std::size_t s_clade_count(std::size_t node_idx) const {
+    return node_topologies_[node_idx].clade_count_;
+  }
+
+  void s_dealloc_clade_offsets(std::size_t start, std::size_t count) {
+    clade_offsets_.remove(start, count);
+  }
+
+  template <typename F>
+  void s_build_all_clade_offsets(F&& get_edge_clade_idx) {
+    for (auto& ntopo : node_topologies_) {
+      // Deallocate old offsets if any
+      if (ntopo.clade_count_ > 0) {
+        clade_offsets_.remove(ntopo.clade_offsets_start_,
+                              ntopo.clade_count_ + 1);
+        ntopo.clade_offsets_start_ = no_idx;
+        ntopo.clade_count_ = 0;
+      }
+      if (ntopo.children_count_ == 0) continue;
+
+      // Collect (clade_idx, edge_idx) pairs from children section
+      auto sec = typename chain<std::size_t>::contiguous_section{
+          neighbors_, ntopo.children_start_, ntopo.children_count_};
+      std::vector<std::pair<std::size_t, std::size_t>> pairs;
+      pairs.reserve(ntopo.children_count_);
+      for (std::size_t i = 0; i < sec.size(); ++i)
+        pairs.emplace_back(get_edge_clade_idx(sec[i]), sec[i]);
+
+      // Sort by clade index (stable to preserve order within clades)
+      std::stable_sort(pairs.begin(), pairs.end(),
+                       [](auto const& a, auto const& b) {
+                         return a.first < b.first;
+                       });
+
+      // Write back sorted edge indices
+      for (std::size_t i = 0; i < pairs.size(); ++i) sec[i] = pairs[i].second;
+
+      // Build CSR offsets
+      std::size_t num_clades = pairs.back().first + 1;
+      std::vector<std::size_t> offsets(num_clades + 1, 0);
+      for (auto const& [clade, _] : pairs) offsets[clade + 1]++;
+      for (std::size_t i = 1; i <= num_clades; ++i) offsets[i] += offsets[i - 1];
+
+      auto off_sec = clade_offsets_.move_range(std::move(offsets));
+      ntopo.clade_offsets_start_ = off_sec.start();
+      ntopo.clade_count_ = num_clades;
+    }
+  }
+
+  void s_invalidate_clade_offsets(node_topology<N>& ntopo) {
+    if (ntopo.clade_count_ > 0) {
+      clade_offsets_.remove(ntopo.clade_offsets_start_,
+                            ntopo.clade_count_ + 1);
+      ntopo.clade_offsets_start_ = no_idx;
+      ntopo.clade_count_ = 0;
+    }
+  }
+
   void s_link_child(std::size_t node_idx, std::size_t edge_idx) {
     auto& ntopo = node_topologies_[node_idx];
+    s_invalidate_clade_offsets(ntopo);
     auto sec = typename chain<std::size_t>::contiguous_section{
         neighbors_, ntopo.children_start_, ntopo.children_count_};
     sec = sec.emplace_back(edge_idx);
@@ -479,6 +583,7 @@ class dag : public dag_interface<N, E> {
   void s_unlink_child(std::size_t node_idx, std::size_t edge_idx) {
     auto& ntopo = node_topologies_[node_idx];
     if (ntopo.children_count_ == 0) return;
+    s_invalidate_clade_offsets(ntopo);
     auto sec = typename chain<std::size_t>::contiguous_section{
         neighbors_, ntopo.children_start_, ntopo.children_count_};
     for (std::size_t i = 0; i < sec.size(); ++i) {
@@ -527,6 +632,8 @@ class dag : public dag_interface<N, E> {
     topo.parents_count_ = 0;
     topo.children_start_ = no_idx;
     topo.children_count_ = 0;
+    topo.clade_offsets_start_ = no_idx;
+    topo.clade_count_ = 0;
     topo.annotation_index_ = ann_idx;
     auto topo_idx = node_topologies_.emplace(topo);
     node_topologies_[topo_idx].self_index_ = topo_idx;
@@ -551,6 +658,9 @@ class dag : public dag_interface<N, E> {
 
   void s_dealloc_node(std::size_t idx, N kind) {
     auto& ntopo = node_topologies_[idx];
+    if (ntopo.clade_count_ > 0)
+      clade_offsets_.remove(ntopo.clade_offsets_start_,
+                            ntopo.clade_count_ + 1);
     detail::enum_dispatch<node_enumerators>::call(kind, [&](auto v) {
       constexpr std::size_t I =
           node_enumerators::template index_of<decltype(v)::value>;
@@ -632,6 +742,21 @@ auto node_view<D, V>::get_parents() {
 
 template <typename D, auto V>
   requires Enum<decltype(V)>
+auto node_view<D, V>::get_clade(std::size_t clade_i) {
+  auto sec = dag_.clade_section(index_, clade_i);
+  return std::views::transform(std::move(sec), [this](auto& idx) {
+    return dag_.make_edge_variant(idx);
+  });
+}
+
+template <typename D, auto V>
+  requires Enum<decltype(V)>
+std::size_t node_view<D, V>::clade_count() const {
+  return dag_.clade_count(index_);
+}
+
+template <typename D, auto V>
+  requires Enum<decltype(V)>
 void node_view<D, V>::remove() {
   auto& ntopo = dag_.node_topo(index_);
 
@@ -658,6 +783,12 @@ void node_view<D, V>::remove() {
     dag_.dealloc_neighbors(ntopo.parents_start_, ntopo.parents_count_);
   if (ntopo.children_count_ > 0)
     dag_.dealloc_neighbors(ntopo.children_start_, ntopo.children_count_);
+  if (ntopo.clade_count_ > 0) {
+    dag_.dealloc_clade_offsets(ntopo.clade_offsets_start_,
+                               ntopo.clade_count_ + 1);
+    ntopo.clade_offsets_start_ = no_idx;
+    ntopo.clade_count_ = 0;
+  }
 
   dag_.dealloc_node(index_, ntopo.kind_);
 }

--- a/include/larch/extend_dag.hpp
+++ b/include/larch/extend_dag.hpp
@@ -78,6 +78,12 @@ class extend_dag
   auto s_parents_section(std::size_t node_idx) {
     return base_.parents_section(node_idx);
   }
+  auto s_clade_section(std::size_t node_idx, std::size_t clade_i) {
+    return base_.clade_section(node_idx, clade_i);
+  }
+  std::size_t s_clade_count(std::size_t node_idx) const {
+    return base_.clade_count(node_idx);
+  }
 
   void s_link_child(std::size_t node_idx, std::size_t edge_idx) {
     base_.link_child(node_idx, edge_idx);
@@ -109,6 +115,13 @@ class extend_dag
   }
   void s_dealloc_neighbors(std::size_t start, std::size_t count) {
     base_.dealloc_neighbors(start, count);
+  }
+  void s_dealloc_clade_offsets(std::size_t start, std::size_t count) {
+    base_.dealloc_clade_offsets(start, count);
+  }
+  template <typename F>
+  void s_build_all_clade_offsets(F&& get_edge_clade_idx) {
+    base_.build_all_clade_offsets(std::forward<F>(get_edge_clade_idx));
   }
 
   auto& s_node_topos() { return base_.node_topos(); }

--- a/include/larch/load_parsimony.hpp
+++ b/include/larch/load_parsimony.hpp
@@ -239,6 +239,7 @@ inline phylo_dag load_parsimony_tree(std::string_view path,
         nv);
   }
 
+  build_clade_offsets(d);
   return d;
 }
 

--- a/include/larch/load_proto_dag.hpp
+++ b/include/larch/load_proto_dag.hpp
@@ -239,6 +239,7 @@ inline phylo_dag load_proto_dag(std::string_view path) {
     }
   }
 
+  build_clade_offsets(d);
   return d;
 }
 

--- a/include/larch/merge.hpp
+++ b/include/larch/merge.hpp
@@ -666,13 +666,10 @@ class merge {
     if (!result_built_) {
       result_dag_ = phylo_dag{};
       build_result();
-      // SPR fragment merging can create clade alternatives whose subtrees are
-      // missing leaves (orphan reconnection may attach a fragment covering
-      // only a subset of a clade's leaves).  These incomplete alternatives
-      // produce artificially low edge-mutation counts that mislead
-      // compute_weight_below and min_weight_sample_tree — the sampled "tree"
-      // may have fewer leaves than the DAG.  Trim them immediately so every
-      // caller sees a structurally valid DAG.
+      // Safety net: trim incomplete-leaf-set clade alternatives that may
+      // exist in DAGs loaded from older protobuf files.  For freshly
+      // generated fragments this should be a no-op (the fragment-root fix
+      // ensures fragments capture the full affected subtree).
       trim_inconsistent_clade_edges(result_dag_);
       build_clade_offsets(result_dag_);
     }

--- a/include/larch/merge.hpp
+++ b/include/larch/merge.hpp
@@ -674,6 +674,7 @@ class merge {
       // may have fewer leaves than the DAG.  Trim them immediately so every
       // caller sees a structurally valid DAG.
       trim_inconsistent_clade_edges(result_dag_);
+      build_clade_offsets(result_dag_);
     }
     return result_dag_;
   }

--- a/include/larch/overlay_dag.hpp
+++ b/include/larch/overlay_dag.hpp
@@ -51,6 +51,11 @@ class overlay_dag
     auto& dst = overlaid_nodes_[idx];
     dst = src;
 
+    // Invalidate clade offsets (overlay topology changes make them stale;
+    // base offsets reference the base's clade_offsets_ chain, not the overlay's)
+    dst.clade_offsets_start_ = no_idx;
+    dst.clade_count_ = 0;
+
     // Copy children neighbor list into overlay_neighbors_
     if (src.children_count_ > 0) {
       auto csec = base_.children_section(idx);
@@ -205,6 +210,26 @@ class overlay_dag
     return base_.parents_section(node_idx);
   }
 
+  auto s_clade_section(std::size_t node_idx, std::size_t clade_i) {
+    // Overlaid/added nodes have clade_count_==0; callers should not reach here.
+    // Non-overlaid base nodes delegate to the base's clade offsets.
+    assert(!overlaid_nodes_.contains(node_idx) && !is_added_node(node_idx));
+    return base_.clade_section(node_idx, clade_i);
+  }
+
+  std::size_t s_clade_count(std::size_t node_idx) const {
+    return s_node_topo(node_idx).clade_count_;
+  }
+
+  void s_dealloc_clade_offsets(std::size_t /*start*/, std::size_t /*count*/) {
+    // Overlay never owns clade offsets; dealloc is a no-op.
+  }
+
+  template <typename F>
+  void s_build_all_clade_offsets(F&&) {
+    // Clade offsets are not supported on overlay DAGs.
+  }
+
   void ensure_overlaid(std::size_t node_idx) {
     if (!overlaid_nodes_.contains(node_idx) && !is_added_node(node_idx))
       set_overlay_node(node_idx);
@@ -273,6 +298,8 @@ class overlay_dag
     topo.parents_count_ = 0;
     topo.children_start_ = no_idx;
     topo.children_count_ = 0;
+    topo.clade_offsets_start_ = no_idx;
+    topo.clade_count_ = 0;
     topo.annotation_index_ = 0;  // not used — annotations keyed by DAG index
 
     auto local_idx = added_nodes_.emplace(topo);

--- a/include/larch/overlay_spr.hpp
+++ b/include/larch/overlay_spr.hpp
@@ -5,6 +5,7 @@
 #include <larch/native_optimize.hpp>
 #include <larch/spr_move.hpp>
 
+#include <cassert>
 #include <functional>
 #include <memory_resource>
 #include <unordered_map>
@@ -74,6 +75,21 @@ std::size_t child_count_of(Dag& d, std::size_t node_idx) {
       },
       nv);
   return count;
+}
+
+template <typename Dag>
+std::pmr::vector<std::size_t> get_child_edges_of(
+    Dag& d, std::size_t node_idx, std::pmr::memory_resource* mr) {
+  std::pmr::vector<std::size_t> result(mr);
+  auto nv = d.get_node(node_idx);
+  std::visit(
+      [&](auto node) {
+        for (auto ev : node.get_children()) {
+          std::visit([&](auto edge) { result.push_back(edge.index()); }, ev);
+        }
+      },
+      nv);
+  return result;
 }
 
 }  // namespace overlay_detail
@@ -192,10 +208,15 @@ inline std::size_t apply_spr_topology(
 
   // Determine fragment root:
   // If LCA was collapsed (src_parent == lca and was binary), use grandparent.
-  // But if grandparent is UA, use the remaining child (it's the new tree root).
+  // But if grandparent is UA, find UA's actual child in the overlay — the SPR
+  // may have created a new inner node that is now the tree root.  Returning
+  // remaining_child_after_collapse would miss the new inner node and the
+  // moved source, producing an incomplete fragment.
   if (src_parent_collapsed && src_parent == lca) {
     if (is_ua(base, grandparent)) {
-      return remaining_child_after_collapse;
+      auto ua_children = overlay_detail::get_child_edges_of(ov, grandparent, mr);
+      assert(!ua_children.empty());
+      return overlay_detail::get_child_idx_of(ov, ua_children[0]);
     }
     return grandparent;
   }

--- a/test/spr_pipeline_test.cpp
+++ b/test/spr_pipeline_test.cpp
@@ -470,6 +470,113 @@ static void test_optimize_dag_v2_on_proto_data() {
 }
 
 // ---------------------------------------------------------------------------
+// Test 9: UA-grandparent fragment root captures full tree
+// ---------------------------------------------------------------------------
+//
+// Regression test for the fragment_root determination bug.  When the LCA
+// equals the tree root (binary, child of UA) and collapses during the SPR,
+// the old code returned remaining_child_after_collapse, producing a fragment
+// that missed the new inner node and the moved source.  The fix returns
+// UA's actual child after the full SPR topology change.
+//
+// Tree:
+//     UA
+//      |
+//    root
+//    /   \
+//  leafA  P
+//        / \
+//     leafB leafC
+//
+// SPR: src=leafA, dst=P  →  root collapses, new inner X between UA and P.
+//
+//     UA
+//      |
+//      X (new)
+//     / \
+//    P   leafA
+//   / \
+// leafB leafC
+//
+// Old fragment root = P (missed X and leafA).
+// Fixed fragment root = X (captures the whole tree).
+
+static void test_ua_grandparent_fragment_root() {
+  std::println("test_ua_grandparent_fragment_root");
+
+  constexpr std::string_view ref = "AAAA";
+  phylo_dag tree;
+
+  auto ua = tree.append_node<node_kind::ua>();
+  ua.reference_sequence() = std::string{ref};
+  tree.set_root(ua);
+
+  auto root = tree.append_node<node_kind::inner>();
+  root.cg() = cg_from_sequence("AAAA", ref);
+
+  auto leafA = tree.append_node<node_kind::leaf>();
+  leafA.cg() = cg_from_sequence("TAAA", ref);
+  leafA.sample_id() = "leafA";
+
+  auto P = tree.append_node<node_kind::inner>();
+  P.cg() = cg_from_sequence("ACAA", ref);
+
+  auto leafB = tree.append_node<node_kind::leaf>();
+  leafB.cg() = cg_from_sequence("ACGA", ref);
+  leafB.sample_id() = "leafB";
+
+  auto leafC = tree.append_node<node_kind::leaf>();
+  leafC.cg() = cg_from_sequence("ACAG", ref);
+  leafC.sample_id() = "leafC";
+
+  add_edge(tree, ua.index(), root.index(), 0);
+  add_edge(tree, root.index(), leafA.index(), 0);
+  add_edge(tree, root.index(), P.index(), 1);
+  add_edge(tree, P.index(), leafB.index(), 0);
+  add_edge(tree, P.index(), leafC.index(), 1);
+
+  recompute_edge_mutations(tree);
+  auto original_leaves = get_leaf_ids(tree);
+  assert(original_leaves.size() == 3);
+
+  // SPR: move leafA to be sibling of P  (LCA = root, root collapses)
+  auto lca = compute_lca(tree, leafA.index(), P.index());
+  assert(lca == root.index());
+
+  auto fragment = apply_spr_as_fragment(
+      tree, spr_move{.src = leafA.index(), .dst = P.index(), .lca = lca});
+
+  verify_is_tree(fragment);
+  auto frag_leaves = get_leaf_ids(fragment);
+
+  std::println("  fragment: {} nodes, {} edges, {} leaves",
+               node_count(fragment), edge_count(fragment), frag_leaves.size());
+
+  // The fragment must contain ALL leaves of the original tree.
+  assert(frag_leaves == original_leaves);
+
+  // Merge and verify no trim is needed.
+  merge m(std::string{ref});
+  m.add_dag(tree);
+  m.add_dag(std::move(fragment));
+  auto& result = m.get_result();
+
+  auto result_leaves = get_leaf_ids(result);
+  assert(result_leaves == original_leaves);
+
+  // Verify all sampled trees have the correct leaf count.
+  for (std::uint32_t seed = 0; seed < 20; ++seed) {
+    parsimony_score_ops pops;
+    subtree_weight<parsimony_score_ops> sw(result, seed);
+    auto sampled = sw.min_weight_sample_tree(pops);
+    assert(is_tree(sampled));
+    assert(get_leaf_ids(sampled) == original_leaves);
+  }
+
+  std::println("  PASS");
+}
+
+// ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------
 
@@ -484,6 +591,7 @@ int main() {
   test_optimize_dag_v2_equivalent();
   test_optimize_dag_v2_deterministic();
   test_optimize_dag_v2_on_proto_data();
+  test_ua_grandparent_fragment_root();
 
   std::println("All SPR pipeline tests passed!");
   return 0;


### PR DESCRIPTION
Storing clades separately
Fix for UA-grandparent bug that required a trim_inconsistent_clade_edges() workaround.

A bug in apply_spr_topology when the LCA grandparent is UA the remaining child is a child of the new node. The fragment then is incomplete without the new node.