### PR TITLE
Fix for rotaA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(GCC_TOOLCHAIN)
     set(CMAKE_CXX_COMPILER "${GCC_TOOLCHAIN}/bin/g++${_suffix}"   CACHE FILEPATH "" FORCE)
 endif()
 
-project(larch2 VERSION 2.0.1 LANGUAGES C CXX)
+project(larch2 VERSION 2.0.2 LANGUAGES C CXX)
 
 # On FreeBSD the system ranlib is LLVM's, which rejects the --plugin flag that
 # gcc-ranlib passes.  CMake's IPO uses CMAKE_<LANG>_COMPILER_RANLIB for static

--- a/include/larch/native_optimize.hpp
+++ b/include/larch/native_optimize.hpp
@@ -176,6 +176,7 @@ class tree_index {
   }
   std::size_t num_variable_sites() const { return num_variable_sites_; }
   std::size_t num_condensed_leaves() const { return condensed_count_; }
+  uint8_t const* get_ref_alleles_ptr() const { return ref_alleles_.data(); }
 
  private:
   static constexpr std::size_t kFitchParallelThreshold = 64;
@@ -448,11 +449,16 @@ class tree_index {
   }
 
   void compute_fitch_sets() {
+    auto const& ref = get_reference_sequence(d_);
     if (pool_ && subtree_size_[tree_root_] >= kFitchParallelThreshold) {
-      auto const& ref = get_reference_sequence(d_);
       sync_wait<void>(*pool_, fitch_bottom_up_async(tree_root_, ref));
     } else {
       fitch_bottom_up(tree_root_);
+    }
+    ref_alleles_.resize(num_variable_sites_);
+    for (std::size_t i = 0; i < num_variable_sites_; i++) {
+      auto base = nuc_base::from_char(ref.at(variable_sites_[i] - 1));
+      ref_alleles_[i] = base_to_one_hot(base);
     }
   }
 
@@ -476,6 +482,7 @@ class tree_index {
   std::vector<std::vector<std::size_t>> children_;
   std::vector<uint8_t> is_condensed_;
   std::vector<std::size_t> subtree_size_;
+  std::vector<uint8_t> ref_alleles_;
   std::size_t condensed_count_{0};
 };
 
@@ -648,6 +655,67 @@ class move_enumerator {
         total_score_change += new_cost - old_cost;
         new_fitch_map[node] = new_fitch;
       }
+
+      if (src_parent_is_binary) {
+        if (new_fitch_map.count(src_sibling)) {
+          new_fitch_map[lca] = new_fitch_map[src_sibling];
+        } else if (dst == src_sibling) {
+          new_fitch_map[lca] = new_node_fitch;
+        }
+      }
+
+      uint8_t root_old_f = index_.get_fitch_set(index_.get_tree_root(), si);
+      uint8_t root_new_f = root_old_f;
+
+      auto lca_new_it = new_fitch_map.find(lca);
+      if (lca_new_it != new_fitch_map.end()) {
+        if (lca == index_.get_tree_root()) {
+          root_new_f = lca_new_it->second;
+        } else {
+          uint8_t lca_orig = index_.get_fitch_set(lca, si);
+          if (lca_new_it->second != lca_orig) {
+            uint8_t prev_old_f = lca_orig;
+            uint8_t prev_new_f = lca_new_it->second;
+            auto above = index_.get_parent(lca);
+            while (true) {
+              if (!index_.has_child_counts(above)) break;
+
+              auto counts = index_.get_child_counts(above, si);
+              uint8_t nc = index_.get_num_children(above);
+              int old_cost_above = fitch_cost_from_counts(counts, nc);
+
+              for (int j = 0; j < 4; j++) {
+                if (prev_old_f & (1 << j)) {
+                  if (counts[j] > 0) counts[j]--;
+                }
+                if (prev_new_f & (1 << j)) counts[j]++;
+              }
+
+              int new_cost_above = fitch_cost_from_counts(counts, nc);
+              total_score_change += new_cost_above - old_cost_above;
+
+              uint8_t above_orig = index_.get_fitch_set(above, si);
+              uint8_t above_new = fitch_set_from_counts(counts, nc);
+              if (above_new == above_orig) break;
+
+              prev_old_f = above_orig;
+              prev_new_f = above_new;
+              if (above == index_.get_tree_root()) {
+                root_new_f = above_new;
+                break;
+              }
+              above = index_.get_parent(above);
+            }
+          }
+        }
+      }
+
+      if (root_old_f != root_new_f) {
+        uint8_t ref_a = index_.get_ref_alleles_ptr()[si];
+        int old_ua = (root_old_f & ref_a) ? 0 : 1;
+        int new_ua = (root_new_f & ref_a) ? 0 : 1;
+        total_score_change += new_ua - old_ua;
+      }
     }
 
     return total_score_change;
@@ -771,6 +839,8 @@ class move_enumerator {
         cur = index_.get_parent(cur);
       }
       nodes_remaining++;
+      nodes_remaining +=
+          static_cast<int>(index_.get_dfs_info(lca).level);
     }
 
     auto const* src_fitch_ptr = index_.get_fitch_set_ptr(src);
@@ -851,7 +921,32 @@ class move_enumerator {
         return total;
       }
 
-      if (node == lca) break;
+      bool fitch_changed = false;
+      for (std::size_t si = 0; si < n_sites; si++) {
+        if (prev_old_fitch[si] != prev_new_fitch[si]) {
+          fitch_changed = true;
+          break;
+        }
+      }
+
+      bool is_current_lca = (node == lca);
+
+      if (is_current_lca && !fitch_changed) break;
+      if (!is_current_lca && nodes_remaining < 0 && !fitch_changed) break;
+
+      if (node == index_.get_tree_root()) {
+        auto const* ref_alleles = index_.get_ref_alleles_ptr();
+        for (std::size_t si = 0; si < n_sites; si++) {
+          uint8_t old_f = prev_old_fitch[si];
+          uint8_t new_f = prev_new_fitch[si];
+          if (old_f != new_f) {
+            int old_ua = (old_f & ref_alleles[si]) ? 0 : 1;
+            int new_ua = (new_f & ref_alleles[si]) ? 0 : 1;
+            total += new_ua - old_ua;
+          }
+        }
+        break;
+      }
       node = index_.get_parent(node);
       is_first = false;
     }

--- a/test/native_optimize_test.cpp
+++ b/test/native_optimize_test.cpp
@@ -421,6 +421,92 @@ static void test_dag_grows() {
 }
 
 // ---------------------------------------------------------------------------
+// Test: verify predicted score change matches ground truth (mutation count)
+// ---------------------------------------------------------------------------
+
+static std::size_t count_tree_mutations(phylo_dag& tree) {
+  std::size_t total = 0;
+  for (auto ev : tree.get_all_edges()) {
+    std::visit([&](auto edge) { total += edge.mutations().size(); }, ev);
+  }
+  return total;
+}
+
+static void test_score_vs_ground_truth() {
+  std::println("test_score_vs_ground_truth");
+
+  auto tree = make_suboptimal_tree();
+  auto original_score = count_tree_mutations(tree);
+  std::println("  original score: {}", original_score);
+
+  tree_index idx{tree};
+  move_enumerator enumerator{idx};
+  auto radius = compute_tree_max_depth(tree) * 2;
+
+  std::vector<profitable_move> all_moves;
+  enumerator.find_all_moves(radius, [&](auto& m) { all_moves.push_back(m); });
+
+  // Also check all src/dst pairs (brute force) for completeness
+  auto& searchable = idx.get_searchable_nodes();
+  std::vector<profitable_move> brute_moves;
+
+  for (auto src : searchable) {
+    std::vector<std::size_t> ancestors;
+    auto cur = idx.get_parent(src);
+    while (idx.has_dfs_info(cur)) {
+      ancestors.push_back(cur);
+      if (cur == idx.get_tree_root()) break;
+      cur = idx.get_parent(cur);
+    }
+
+    for (auto dst_nv : tree.get_all_nodes()) {
+      std::visit(
+          [&](auto dst_node) {
+            auto dst = dst_node.index();
+            if (is_ua(tree, dst)) return;
+            if (dst == idx.get_tree_root()) return;
+            if (dst == src) return;
+            if (idx.is_ancestor(src, dst)) return;
+            if (idx.is_ancestor(dst, src)) return;
+            if (!idx.has_dfs_info(dst)) return;
+
+            for (auto lca : ancestors) {
+              if (idx.is_ancestor(lca, dst)) {
+                int score = enumerator.compute_move_score(src, dst, lca);
+                if (score < 0) {
+                  brute_moves.push_back(
+                      profitable_move{src, dst, lca, score});
+                }
+                break;
+              }
+            }
+          },
+          dst_nv);
+    }
+  }
+
+  std::size_t mismatches = 0;
+  auto check_move = [&](profitable_move const& m, char const* label) {
+    auto result = apply_spr_move(tree, m.src, m.dst);
+    auto actual_score = static_cast<int>(count_tree_mutations(result));
+    int actual_change = actual_score - static_cast<int>(original_score);
+    if (actual_change != m.score_change) {
+      std::println("  {} MISMATCH: src={} dst={} lca={} predicted={} actual={}",
+                   label, m.src, m.dst, m.lca, m.score_change, actual_change);
+      mismatches++;
+    }
+  };
+
+  for (auto& m : all_moves) check_move(m, "enumerated");
+  for (auto& m : brute_moves) check_move(m, "brute");
+
+  std::println("  checked {} enumerated + {} brute moves, {} mismatches",
+               all_moves.size(), brute_moves.size(), mismatches);
+  assert(mismatches == 0);
+  std::println("  PASS");
+}
+
+// ---------------------------------------------------------------------------
 // Test 6: sampled trees are valid after optimization
 // ---------------------------------------------------------------------------
 
@@ -569,6 +655,7 @@ int main() {
   test_enumerator_finds_moves();
   test_cached_vs_independent();
   test_pruned_vs_exhaustive();
+  test_score_vs_ground_truth();
   test_dag_grows();
   test_valid_dag();
   test_native_5_trees();

--- a/tools/larch2.cpp
+++ b/tools/larch2.cpp
@@ -1319,7 +1319,8 @@ static std::vector<optimize_result> run_native(merge& m, args const& a) {
       parallel_with_progress(
           pool, spr_moves.size(),
           [&](std::size_t i) {
-            fragments[i] = apply_spr_as_fragment(sampled, spr_moves[i]);
+            fragments[i] =
+                apply_spr_move(sampled, spr_moves[i].src, spr_moves[i].dst);
           },
           prog);
 


### PR DESCRIPTION
Bug 1: Scoring stopped at LCA (native_optimize.hpp)

Both compute_move_score and compute_move_score_cached stopped propagating Fitch changes at the LCA. If the
LCA's Fitch set changed, the cost change above it was missed. Fix: continue propagation past the LCA when Fitch
sets change, stopping when they stabilize or at root.

Bug 2: UA→root edge cost ignored (native_optimize.hpp)

The scoring computed Fitch costs at internal nodes but ignored mutations on the edge from the reference
ancestor (UA) to the tree root. When a move changes the root's Fitch set, the root CG changes, adding/removing
UA→root mutations. This caused a systematic off-by-one error - every move was scored 1 step too optimistically.
Fix: store reference alleles in tree_index; after propagating to root, adjust score for UA→root edge cost
change.

Bug 3: Fragment merge loses above-LCA improvements (larch2.cpp)

apply_spr_as_fragment extracted only the LCA subtree. The fragment's Fitch assignment used the reference
sequence as parent context instead of the actual tree parent CG. CG changes cascading above the LCA weren't
captured, so correctly-scored -1 moves produced fragments that didn't improve the DAG's minimum parsimony. Fix:
use apply_spr_move (full tree) instead of apply_spr_as_fragment.