### PR TITLE
Support exact IUPAC ambiguity state sets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ foreach(test_name merge_test merge_consistency_test subtree_weight_test
                   weight_accum_test optimize_test native_optimize_test
                   spr_pipeline_test trim_clade_edges_test
                   # rotaA_diagnostic_test
-                  inplace_spr_test)
+                  inplace_spr_test iupac_correctness_test)
     add_executable(${test_name} test/${test_name}.cpp)
     target_link_libraries(${test_name} PRIVATE larch)
     add_test(NAME ${test_name} COMMAND ${test_name}

--- a/include/larch/compact_genome.hpp
+++ b/include/larch/compact_genome.hpp
@@ -17,6 +17,9 @@
 
 namespace larch {
 
+using iupac_state_set_t = uint8_t;
+using ambiguity_set_map = std::map<mutation_position, iupac_state_set_t>;
+
 inline bool is_unambiguous_nuc_char(char c) {
   switch (c) {
     case 'A':
@@ -33,7 +36,7 @@ inline bool is_unambiguous_nuc_char(char c) {
   }
 }
 
-inline uint8_t iupac_state_set(char c) {
+inline iupac_state_set_t iupac_state_set(char c) {
   switch (c) {
     case 'A':
     case 'a':
@@ -92,7 +95,7 @@ inline bool is_iupac_ambiguity_char(char c) {
   return s != 0 && std::popcount(s) != 1;
 }
 
-inline char iupac_char_from_state_set(uint8_t state_set) {
+inline char iupac_char_from_state_set(iupac_state_set_t state_set) {
   switch (state_set & 0b1111) {
     case 0b0001:
       return 'A';
@@ -175,7 +178,7 @@ inline void warn_if_ambiguities(ambiguity_counts const& counts,
 
 class compact_genome {
   std::map<mutation_position, nuc_base> mutations_;
-  std::map<mutation_position, uint8_t> ambiguity_sets_;
+  ambiguity_set_map ambiguity_sets_;
   std::size_t hash_ = 0;
 
   static void hash_combine(std::size_t& result, std::size_t value) {
@@ -185,7 +188,7 @@ class compact_genome {
 
   static std::size_t compute_hash(
       std::map<mutation_position, nuc_base> const& mutations,
-      std::map<mutation_position, uint8_t> const& ambiguity_sets) {
+      ambiguity_set_map const& ambiguity_sets) {
     std::size_t result = 0;
     for (auto [pos, base] : mutations) {
       hash_combine(result, pos);
@@ -221,7 +224,7 @@ class compact_genome {
   }
 
   compact_genome(std::map<mutation_position, nuc_base> mutations,
-                 std::map<mutation_position, uint8_t> ambiguity_sets)
+                 ambiguity_set_map ambiguity_sets)
       : mutations_{std::move(mutations)},
         ambiguity_sets_{std::move(ambiguity_sets)} {
     for (auto it = ambiguity_sets_.begin(); it != ambiguity_sets_.end();) {
@@ -301,8 +304,8 @@ class compact_genome {
     return nuc_base::from_char(reference.at(pos - 1));
   }
 
-  uint8_t get_state_set(mutation_position pos,
-                        std::string_view reference) const {
+  iupac_state_set_t get_state_set(mutation_position pos,
+                                  std::string_view reference) const {
     auto ait = ambiguity_sets_.find(pos);
     if (ait != ambiguity_sets_.end()) return ait->second;
     return static_cast<uint8_t>(1 << get_base(pos, reference).raw());
@@ -312,9 +315,7 @@ class compact_genome {
     return ambiguity_sets_.contains(pos);
   }
 
-  std::map<mutation_position, uint8_t> const& ambiguity_sets() const {
-    return ambiguity_sets_;
-  }
+  ambiguity_set_map const& ambiguity_sets() const { return ambiguity_sets_; }
 
   std::set<mutation_position> ambiguity_mask() const {
     std::set<mutation_position> result;
@@ -329,7 +330,7 @@ class compact_genome {
     recompute_hash();
   }
 
-  void set_ambiguity_sets(std::map<mutation_position, uint8_t> ambiguity_sets) {
+  void set_ambiguity_sets(ambiguity_set_map ambiguity_sets) {
     ambiguity_sets_ = std::move(ambiguity_sets);
     for (auto it = ambiguity_sets_.begin(); it != ambiguity_sets_.end();) {
       it->second &= 0b1111;
@@ -343,7 +344,8 @@ class compact_genome {
     recompute_hash();
   }
 
-  void add_ambiguous_site(mutation_position pos, uint8_t state_set = 0b1111) {
+  void add_ambiguous_site(mutation_position pos,
+                          iupac_state_set_t state_set = 0b1111) {
     state_set &= 0b1111;
     if (state_set == 0 || std::popcount(state_set) == 1) return;
     mutations_.erase(pos);
@@ -384,7 +386,7 @@ inline compact_genome compact_genome_from_sequence(
     std::string_view sequence, std::string_view reference,
     ambiguity_counts* counts = nullptr) {
   std::map<mutation_position, nuc_base> muts;
-  std::map<mutation_position, uint8_t> ambiguity_sets;
+  ambiguity_set_map ambiguity_sets;
   auto n = std::min(sequence.size(), reference.size());
   if (counts) counts->observed_sites += n;
 

--- a/include/larch/compact_genome.hpp
+++ b/include/larch/compact_genome.hpp
@@ -3,40 +3,162 @@
 #include <larch/nuc.hpp>
 #include <larch/edge_mutations.hpp>
 
+#include <algorithm>
+#include <array>
+#include <cctype>
 #include <cstddef>
 #include <functional>
+#include <iostream>
 #include <map>
+#include <set>
 #include <string>
 #include <string_view>
 
 namespace larch {
 
+inline bool is_unambiguous_nuc_char(char c) {
+  switch (c) {
+    case 'A':
+    case 'a':
+    case 'C':
+    case 'c':
+    case 'G':
+    case 'g':
+    case 'T':
+    case 't':
+      return true;
+    default:
+      return false;
+  }
+}
+
+inline bool is_iupac_ambiguity_char(char c) {
+  switch (c) {
+    case 'N':
+    case 'n':
+    case 'R':
+    case 'r':
+    case 'Y':
+    case 'y':
+    case 'S':
+    case 's':
+    case 'W':
+    case 'w':
+    case 'K':
+    case 'k':
+    case 'M':
+    case 'm':
+    case 'B':
+    case 'b':
+    case 'D':
+    case 'd':
+    case 'H':
+    case 'h':
+    case 'V':
+    case 'v':
+    case '-':
+    case '?':
+      return true;
+    default:
+      return false;
+  }
+}
+
+inline char normalized_ambiguity_char(char c) {
+  if (c == '-') return '-';
+  if (c == '?') return '?';
+  return static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+}
+
+struct ambiguity_counts {
+  std::array<std::size_t, 256> by_char{};
+  std::size_t total = 0;
+  std::size_t observed_sites = 0;
+
+  void add(char c) {
+    auto uc = static_cast<unsigned char>(normalized_ambiguity_char(c));
+    by_char[uc]++;
+    total++;
+  }
+};
+
+inline void warn_if_ambiguities(ambiguity_counts const& counts,
+                                std::string_view label) {
+  if (counts.total == 0) return;
+
+  std::cerr << "warning: " << label << " contains ";
+  bool first = true;
+  auto emit = [&](char c) {
+    auto n = counts.by_char[static_cast<unsigned char>(c)];
+    if (n == 0) return;
+    if (!first) std::cerr << ", ";
+    first = false;
+    std::cerr << c << "=" << n;
+  };
+  for (char c : std::string_view{"NRYWSKMBDHV-?"}) emit(c);
+
+  double pct = counts.observed_sites > 0
+                   ? (100.0 * static_cast<double>(counts.total) /
+                      static_cast<double>(counts.observed_sites))
+                   : 0.0;
+  std::cerr << " ambiguity/no-call codes (" << pct
+            << "% of observed sites). These will be treated as no-calls "
+               "during compact-genome construction; no edge mutations are "
+               "emitted at those sites and Fitch parsimony treats them as "
+               "compatible with any nucleotide.\n";
+}
+
 class compact_genome {
   std::map<mutation_position, nuc_base> mutations_;
+  std::set<mutation_position> ambiguity_mask_;
   std::size_t hash_ = 0;
 
+  static void hash_combine(std::size_t& result, std::size_t value) {
+    result ^= std::hash<std::size_t>{}(value) + 0x9e3779b9 + (result << 6) +
+              (result >> 2);
+  }
+
   static std::size_t compute_hash(
-      std::map<mutation_position, nuc_base> const& mutations) {
+      std::map<mutation_position, nuc_base> const& mutations,
+      std::set<mutation_position> const& ambiguity_mask) {
     std::size_t result = 0;
     for (auto [pos, base] : mutations) {
-      result ^= std::hash<std::size_t>{}(pos) + 0x9e3779b9 + (result << 6) +
-                (result >> 2);
-      result ^=
-          std::hash<std::size_t>{}(static_cast<std::size_t>(base.to_char())) +
-          0x9e3779b9 + (result << 6) + (result >> 2);
+      hash_combine(result, pos);
+      hash_combine(result, static_cast<std::size_t>(base.to_char()));
+    }
+
+    // Preserve the exact historical hash for ACGT-only compact genomes.
+    if (!ambiguity_mask.empty()) {
+      hash_combine(result, static_cast<std::size_t>('?'));
+      for (auto pos : ambiguity_mask) hash_combine(result, pos);
     }
     return result;
   }
+
+  void recompute_hash() { hash_ = compute_hash(mutations_, ambiguity_mask_); }
 
  public:
   compact_genome() = default;
 
   explicit compact_genome(std::map<mutation_position, nuc_base> mutations)
-      : mutations_{std::move(mutations)}, hash_{compute_hash(mutations_)} {}
+      : mutations_{std::move(mutations)},
+        hash_{compute_hash(mutations_, ambiguity_mask_)} {}
+
+  compact_genome(std::map<mutation_position, nuc_base> mutations,
+                 std::set<mutation_position> ambiguity_mask)
+      : mutations_{std::move(mutations)},
+        ambiguity_mask_{std::move(ambiguity_mask)},
+        hash_{compute_hash(mutations_, ambiguity_mask_)} {
+    for (auto pos : ambiguity_mask_) mutations_.erase(pos);
+    recompute_hash();
+  }
 
   void add_parent_edge(edge_mutations const& muts, compact_genome const& parent,
                        std::string_view reference) {
-    // Start with parent's mutations
+    // Start with parent's concrete mutations. Edge mutations are fully
+    // disambiguated; ambiguity masks are leaf-local no-calls and do not
+    // propagate through internal nodes.
+    ambiguity_mask_.clear();
     for (auto [pos, base] : parent.mutations_) {
       mutations_.insert_or_assign(pos, base);
     }
@@ -56,7 +178,7 @@ class compact_genome {
         }
       }
     }
-    hash_ = compute_hash(mutations_);
+    recompute_hash();
   }
 
   static edge_mutations to_edge_mutations(std::string_view reference,
@@ -64,6 +186,7 @@ class compact_genome {
                                           compact_genome const& child) {
     edge_mutations result;
     for (auto [pos, child_base] : child.mutations_) {
+      if (parent.is_ambiguous(pos) || child.is_ambiguous(pos)) continue;
       nuc_base parent_base = nuc_base::from_char(reference.at(pos - 1));
       auto it = parent.mutations_.find(pos);
       if (it != parent.mutations_.end()) {
@@ -74,6 +197,7 @@ class compact_genome {
       }
     }
     for (auto [pos, parent_base] : parent.mutations_) {
+      if (parent.is_ambiguous(pos) || child.is_ambiguous(pos)) continue;
       nuc_base child_base = nuc_base::from_char(reference.at(pos - 1));
       auto it = child.mutations_.find(pos);
       if (it != child.mutations_.end()) {
@@ -94,6 +218,26 @@ class compact_genome {
     return nuc_base::from_char(reference.at(pos - 1));
   }
 
+  bool is_ambiguous(mutation_position pos) const {
+    return ambiguity_mask_.contains(pos);
+  }
+
+  std::set<mutation_position> const& ambiguity_mask() const {
+    return ambiguity_mask_;
+  }
+
+  void set_ambiguity_mask(std::set<mutation_position> ambiguity_mask) {
+    ambiguity_mask_ = std::move(ambiguity_mask);
+    for (auto pos : ambiguity_mask_) mutations_.erase(pos);
+    recompute_hash();
+  }
+
+  void add_ambiguous_site(mutation_position pos) {
+    mutations_.erase(pos);
+    ambiguity_mask_.insert(pos);
+    recompute_hash();
+  }
+
   std::string to_string() const {
     std::string result = "<";
     for (auto [pos, base] : mutations_) {
@@ -101,11 +245,15 @@ class compact_genome {
       result += base.to_char();
       result += ",";
     }
+    for (auto pos : ambiguity_mask_) {
+      result += std::to_string(pos);
+      result += "?,";
+    }
     result += ">";
     return result;
   }
 
-  bool empty() const { return mutations_.empty(); }
+  bool empty() const { return mutations_.empty() && ambiguity_mask_.empty(); }
   std::size_t hash() const { return hash_; }
 
   auto begin() const { return mutations_.begin(); }
@@ -113,9 +261,33 @@ class compact_genome {
 
   bool operator==(compact_genome const& rhs) const {
     if (hash_ != rhs.hash_) return false;
-    return mutations_ == rhs.mutations_;
+    return mutations_ == rhs.mutations_ &&
+           ambiguity_mask_ == rhs.ambiguity_mask_;
   }
 };
+
+inline compact_genome compact_genome_from_sequence(
+    std::string_view sequence, std::string_view reference,
+    ambiguity_counts* counts = nullptr) {
+  std::map<mutation_position, nuc_base> muts;
+  std::set<mutation_position> ambiguity_mask;
+  auto n = std::min(sequence.size(), reference.size());
+  if (counts) counts->observed_sites += n;
+
+  for (std::size_t i = 0; i < n; ++i) {
+    char c = sequence[i];
+    if (is_iupac_ambiguity_char(c)) {
+      ambiguity_mask.insert(static_cast<mutation_position>(i + 1));
+      if (counts) counts->add(c);
+      continue;
+    }
+
+    auto ref_base = nuc_base::from_char(reference[i]);
+    auto seq_base = nuc_base::from_char(c);
+    if (!(ref_base == seq_base)) muts[i + 1] = seq_base;
+  }
+  return compact_genome{std::move(muts), std::move(ambiguity_mask)};
+}
 
 }  // namespace larch
 

--- a/include/larch/compact_genome.hpp
+++ b/include/larch/compact_genome.hpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cctype>
 #include <cstddef>
 #include <functional>
@@ -32,35 +33,99 @@ inline bool is_unambiguous_nuc_char(char c) {
   }
 }
 
-inline bool is_iupac_ambiguity_char(char c) {
+inline uint8_t iupac_state_set(char c) {
   switch (c) {
-    case 'N':
-    case 'n':
+    case 'A':
+    case 'a':
+      return 0b0001;
+    case 'C':
+    case 'c':
+      return 0b0010;
+    case 'G':
+    case 'g':
+      return 0b0100;
+    case 'T':
+    case 't':
+      return 0b1000;
     case 'R':
     case 'r':
+      return 0b0101;  // A or G
     case 'Y':
     case 'y':
+      return 0b1010;  // C or T
     case 'S':
     case 's':
+      return 0b0110;  // C or G
     case 'W':
     case 'w':
+      return 0b1001;  // A or T
     case 'K':
     case 'k':
+      return 0b1100;  // G or T
     case 'M':
     case 'm':
+      return 0b0011;  // A or C
     case 'B':
     case 'b':
+      return 0b1110;  // C or G or T
     case 'D':
     case 'd':
+      return 0b1101;  // A or G or T
     case 'H':
     case 'h':
+      return 0b1011;  // A or C or T
     case 'V':
     case 'v':
+      return 0b0111;  // A or C or G
+    case 'N':
+    case 'n':
     case '-':
     case '?':
-      return true;
+      return 0b1111;
     default:
-      return false;
+      return 0;
+  }
+}
+
+inline bool is_iupac_ambiguity_char(char c) {
+  auto s = iupac_state_set(c);
+  return s != 0 && std::popcount(s) != 1;
+}
+
+inline char iupac_char_from_state_set(uint8_t state_set) {
+  switch (state_set & 0b1111) {
+    case 0b0001:
+      return 'A';
+    case 0b0010:
+      return 'C';
+    case 0b0100:
+      return 'G';
+    case 0b1000:
+      return 'T';
+    case 0b0101:
+      return 'R';
+    case 0b1010:
+      return 'Y';
+    case 0b0110:
+      return 'S';
+    case 0b1001:
+      return 'W';
+    case 0b1100:
+      return 'K';
+    case 0b0011:
+      return 'M';
+    case 0b1110:
+      return 'B';
+    case 0b1101:
+      return 'D';
+    case 0b1011:
+      return 'H';
+    case 0b0111:
+      return 'V';
+    case 0b1111:
+      return 'N';
+    default:
+      return '?';
   }
 }
 
@@ -101,16 +166,16 @@ inline void warn_if_ambiguities(ambiguity_counts const& counts,
                    ? (100.0 * static_cast<double>(counts.total) /
                       static_cast<double>(counts.observed_sites))
                    : 0.0;
-  std::cerr << " ambiguity/no-call codes (" << pct
-            << "% of observed sites). These will be treated as no-calls "
-               "during compact-genome construction; no edge mutations are "
-               "emitted at those sites and Fitch parsimony treats them as "
-               "compatible with any nucleotide.\n";
+  std::cerr << " IUPAC ambiguity/no-call codes (" << pct
+            << "% of observed sites). Partial IUPAC codes will be treated as "
+               "compatible state sets during Fitch parsimony; N, gap, and ? "
+               "are treated as no-calls. No edge mutations are emitted at "
+               "ambiguous sites.\n";
 }
 
 class compact_genome {
   std::map<mutation_position, nuc_base> mutations_;
-  std::set<mutation_position> ambiguity_mask_;
+  std::map<mutation_position, uint8_t> ambiguity_sets_;
   std::size_t hash_ = 0;
 
   static void hash_combine(std::size_t& result, std::size_t value) {
@@ -120,7 +185,7 @@ class compact_genome {
 
   static std::size_t compute_hash(
       std::map<mutation_position, nuc_base> const& mutations,
-      std::set<mutation_position> const& ambiguity_mask) {
+      std::map<mutation_position, uint8_t> const& ambiguity_sets) {
     std::size_t result = 0;
     for (auto [pos, base] : mutations) {
       hash_combine(result, pos);
@@ -128,37 +193,55 @@ class compact_genome {
     }
 
     // Preserve the exact historical hash for ACGT-only compact genomes.
-    if (!ambiguity_mask.empty()) {
+    if (!ambiguity_sets.empty()) {
       hash_combine(result, static_cast<std::size_t>('?'));
-      for (auto pos : ambiguity_mask) hash_combine(result, pos);
+      for (auto [pos, state_set] : ambiguity_sets) {
+        hash_combine(result, pos);
+        hash_combine(result, state_set & 0b1111);
+      }
     }
     return result;
   }
 
-  void recompute_hash() { hash_ = compute_hash(mutations_, ambiguity_mask_); }
+  void recompute_hash() { hash_ = compute_hash(mutations_, ambiguity_sets_); }
 
  public:
   compact_genome() = default;
 
   explicit compact_genome(std::map<mutation_position, nuc_base> mutations)
       : mutations_{std::move(mutations)},
-        hash_{compute_hash(mutations_, ambiguity_mask_)} {}
+        hash_{compute_hash(mutations_, ambiguity_sets_)} {}
 
   compact_genome(std::map<mutation_position, nuc_base> mutations,
                  std::set<mutation_position> ambiguity_mask)
+      : mutations_{std::move(mutations)} {
+    for (auto pos : ambiguity_mask) ambiguity_sets_[pos] = 0b1111;
+    for (auto [pos, _] : ambiguity_sets_) mutations_.erase(pos);
+    recompute_hash();
+  }
+
+  compact_genome(std::map<mutation_position, nuc_base> mutations,
+                 std::map<mutation_position, uint8_t> ambiguity_sets)
       : mutations_{std::move(mutations)},
-        ambiguity_mask_{std::move(ambiguity_mask)},
-        hash_{compute_hash(mutations_, ambiguity_mask_)} {
-    for (auto pos : ambiguity_mask_) mutations_.erase(pos);
+        ambiguity_sets_{std::move(ambiguity_sets)} {
+    for (auto it = ambiguity_sets_.begin(); it != ambiguity_sets_.end();) {
+      it->second &= 0b1111;
+      if (it->second == 0 || std::popcount(it->second) == 1) {
+        it = ambiguity_sets_.erase(it);
+      } else {
+        mutations_.erase(it->first);
+        ++it;
+      }
+    }
     recompute_hash();
   }
 
   void add_parent_edge(edge_mutations const& muts, compact_genome const& parent,
                        std::string_view reference) {
     // Start with parent's concrete mutations. Edge mutations are fully
-    // disambiguated; ambiguity masks are leaf-local no-calls and do not
-    // propagate through internal nodes.
-    ambiguity_mask_.clear();
+    // disambiguated; ambiguity sets are leaf-local and do not propagate
+    // through internal nodes.
+    ambiguity_sets_.clear();
     for (auto [pos, base] : parent.mutations_) {
       mutations_.insert_or_assign(pos, base);
     }
@@ -218,23 +301,53 @@ class compact_genome {
     return nuc_base::from_char(reference.at(pos - 1));
   }
 
-  bool is_ambiguous(mutation_position pos) const {
-    return ambiguity_mask_.contains(pos);
+  uint8_t get_state_set(mutation_position pos,
+                        std::string_view reference) const {
+    auto ait = ambiguity_sets_.find(pos);
+    if (ait != ambiguity_sets_.end()) return ait->second;
+    return static_cast<uint8_t>(1 << get_base(pos, reference).raw());
   }
 
-  std::set<mutation_position> const& ambiguity_mask() const {
-    return ambiguity_mask_;
+  bool is_ambiguous(mutation_position pos) const {
+    return ambiguity_sets_.contains(pos);
+  }
+
+  std::map<mutation_position, uint8_t> const& ambiguity_sets() const {
+    return ambiguity_sets_;
+  }
+
+  std::set<mutation_position> ambiguity_mask() const {
+    std::set<mutation_position> result;
+    for (auto [pos, _] : ambiguity_sets_) result.insert(pos);
+    return result;
   }
 
   void set_ambiguity_mask(std::set<mutation_position> ambiguity_mask) {
-    ambiguity_mask_ = std::move(ambiguity_mask);
-    for (auto pos : ambiguity_mask_) mutations_.erase(pos);
+    ambiguity_sets_.clear();
+    for (auto pos : ambiguity_mask) ambiguity_sets_[pos] = 0b1111;
+    for (auto [pos, _] : ambiguity_sets_) mutations_.erase(pos);
     recompute_hash();
   }
 
-  void add_ambiguous_site(mutation_position pos) {
+  void set_ambiguity_sets(std::map<mutation_position, uint8_t> ambiguity_sets) {
+    ambiguity_sets_ = std::move(ambiguity_sets);
+    for (auto it = ambiguity_sets_.begin(); it != ambiguity_sets_.end();) {
+      it->second &= 0b1111;
+      if (it->second == 0 || std::popcount(it->second) == 1) {
+        it = ambiguity_sets_.erase(it);
+      } else {
+        mutations_.erase(it->first);
+        ++it;
+      }
+    }
+    recompute_hash();
+  }
+
+  void add_ambiguous_site(mutation_position pos, uint8_t state_set = 0b1111) {
+    state_set &= 0b1111;
+    if (state_set == 0 || std::popcount(state_set) == 1) return;
     mutations_.erase(pos);
-    ambiguity_mask_.insert(pos);
+    ambiguity_sets_[pos] = state_set;
     recompute_hash();
   }
 
@@ -245,15 +358,16 @@ class compact_genome {
       result += base.to_char();
       result += ",";
     }
-    for (auto pos : ambiguity_mask_) {
+    for (auto [pos, state_set] : ambiguity_sets_) {
       result += std::to_string(pos);
-      result += "?,";
+      result += iupac_char_from_state_set(state_set);
+      result += ",";
     }
     result += ">";
     return result;
   }
 
-  bool empty() const { return mutations_.empty() && ambiguity_mask_.empty(); }
+  bool empty() const { return mutations_.empty() && ambiguity_sets_.empty(); }
   std::size_t hash() const { return hash_; }
 
   auto begin() const { return mutations_.begin(); }
@@ -262,7 +376,7 @@ class compact_genome {
   bool operator==(compact_genome const& rhs) const {
     if (hash_ != rhs.hash_) return false;
     return mutations_ == rhs.mutations_ &&
-           ambiguity_mask_ == rhs.ambiguity_mask_;
+           ambiguity_sets_ == rhs.ambiguity_sets_;
   }
 };
 
@@ -270,14 +384,15 @@ inline compact_genome compact_genome_from_sequence(
     std::string_view sequence, std::string_view reference,
     ambiguity_counts* counts = nullptr) {
   std::map<mutation_position, nuc_base> muts;
-  std::set<mutation_position> ambiguity_mask;
+  std::map<mutation_position, uint8_t> ambiguity_sets;
   auto n = std::min(sequence.size(), reference.size());
   if (counts) counts->observed_sites += n;
 
   for (std::size_t i = 0; i < n; ++i) {
     char c = sequence[i];
-    if (is_iupac_ambiguity_char(c)) {
-      ambiguity_mask.insert(static_cast<mutation_position>(i + 1));
+    auto state_set = iupac_state_set(c);
+    if (state_set != 0 && std::popcount(state_set) != 1) {
+      ambiguity_sets[static_cast<mutation_position>(i + 1)] = state_set;
       if (counts) counts->add(c);
       continue;
     }
@@ -286,7 +401,7 @@ inline compact_genome compact_genome_from_sequence(
     auto seq_base = nuc_base::from_char(c);
     if (!(ref_base == seq_base)) muts[i + 1] = seq_base;
   }
-  return compact_genome{std::move(muts), std::move(ambiguity_mask)};
+  return compact_genome{std::move(muts), std::move(ambiguity_sets)};
 }
 
 }  // namespace larch

--- a/include/larch/compact_genome.hpp
+++ b/include/larch/compact_genome.hpp
@@ -9,8 +9,8 @@
 #include <cctype>
 #include <cstddef>
 #include <functional>
-#include <iostream>
 #include <map>
+#include <ostream>
 #include <set>
 #include <string>
 #include <string_view>
@@ -151,17 +151,17 @@ struct ambiguity_counts {
 };
 
 inline void warn_if_ambiguities(ambiguity_counts const& counts,
-                                std::string_view label) {
+                                std::string_view label, std::ostream& out) {
   if (counts.total == 0) return;
 
-  std::cerr << "warning: " << label << " contains ";
+  out << "warning: " << label << " contains ";
   bool first = true;
   auto emit = [&](char c) {
     auto n = counts.by_char[static_cast<unsigned char>(c)];
     if (n == 0) return;
-    if (!first) std::cerr << ", ";
+    if (!first) out << ", ";
     first = false;
-    std::cerr << c << "=" << n;
+    out << c << "=" << n;
   };
   for (char c : std::string_view{"NRYWSKMBDHV-?"}) emit(c);
 
@@ -169,11 +169,11 @@ inline void warn_if_ambiguities(ambiguity_counts const& counts,
                    ? (100.0 * static_cast<double>(counts.total) /
                       static_cast<double>(counts.observed_sites))
                    : 0.0;
-  std::cerr << " IUPAC ambiguity/no-call codes (" << pct
-            << "% of observed sites). Partial IUPAC codes will be treated as "
-               "compatible state sets during Fitch parsimony; N, gap, and ? "
-               "are treated as no-calls. No edge mutations are emitted at "
-               "ambiguous sites.\n";
+  out << " IUPAC ambiguity/no-call codes (" << pct
+      << "% of observed sites). Partial IUPAC codes will be treated as "
+         "compatible state sets during Fitch parsimony; N, gap, and ? "
+         "are treated as no-calls. No edge mutations are emitted at "
+         "ambiguous sites.\n";
 }
 
 class compact_genome {
@@ -214,14 +214,6 @@ class compact_genome {
   explicit compact_genome(std::map<mutation_position, nuc_base> mutations)
       : mutations_{std::move(mutations)},
         hash_{compute_hash(mutations_, ambiguity_sets_)} {}
-
-  compact_genome(std::map<mutation_position, nuc_base> mutations,
-                 std::set<mutation_position> ambiguity_mask)
-      : mutations_{std::move(mutations)} {
-    for (auto pos : ambiguity_mask) ambiguity_sets_[pos] = 0b1111;
-    for (auto [pos, _] : ambiguity_sets_) mutations_.erase(pos);
-    recompute_hash();
-  }
 
   compact_genome(std::map<mutation_position, nuc_base> mutations,
                  ambiguity_set_map ambiguity_sets)

--- a/include/larch/compute.hpp
+++ b/include/larch/compute.hpp
@@ -10,6 +10,7 @@
 #include <deque>
 #include <functional>
 #include <iostream>
+#include <map>
 #include <memory_resource>
 #include <queue>
 #include <set>
@@ -73,9 +74,9 @@ inline void recompute_compact_genomes(phylo_dag& d) {
             if (cg_set) break;
             std::visit(
                 [&](auto pe) {
-                  auto parent_idx = std::visit(
-                      [](auto parent) { return parent.index(); },
-                      pe.get_parent());
+                  auto parent_idx =
+                      std::visit([](auto parent) { return parent.index(); },
+                                 pe.get_parent());
                   if (!processed.contains(parent_idx)) return;
 
                   auto& edge_muts = pe.mutations();
@@ -89,17 +90,21 @@ inline void recompute_compact_genomes(phylo_dag& d) {
                       pe.get_parent());
 
                   if constexpr (requires { node.cg(); }) {
-                    std::set<mutation_position> existing_mask;
+                    std::map<mutation_position, uint8_t>
+                        existing_ambiguity_sets;
                     bool leaf_node = true;
                     for (auto ce : node.get_children()) {
                       (void)ce;
                       leaf_node = false;
                       break;
                     }
-                    if (leaf_node) existing_mask = node.cg().ambiguity_mask();
+                    if (leaf_node)
+                      existing_ambiguity_sets = node.cg().ambiguity_sets();
                     node.cg() = compact_genome{};
                     node.cg().add_parent_edge(edge_muts, parent_cg, ref);
-                    if (leaf_node) node.cg().set_ambiguity_mask(std::move(existing_mask));
+                    if (leaf_node)
+                      node.cg().set_ambiguity_sets(
+                          std::move(existing_ambiguity_sets));
                   }
                   cg_set = true;
                 },
@@ -791,16 +796,22 @@ inline uint8_t base_to_one_hot(nuc_base b) {
 inline uint8_t fitch_set_from_counts(std::array<uint32_t, 4> const& counts,
                                      uint32_t num_children) {
   if (num_children == 0) return 0;
-  uint8_t intersection = 0;
+
+  // Generalized Fitch/Sankoff for a node with any number of children and
+  // possibly ambiguous child state sets.  If this node is assigned base b,
+  // every child whose optimal state set does not contain b contributes one
+  // change.  Therefore the optimal parent states are exactly the bases that
+  // appear in the largest number of child sets.  For binary nodes this reduces
+  // to the usual intersection-if-nonempty-else-union rule.
+  uint32_t max_count = 0;
+  for (auto count : counts) max_count = std::max(max_count, count);
+
+  uint8_t result = 0;
   for (int i = 0; i < 4; i++) {
-    if (counts[i] == num_children) intersection |= static_cast<uint8_t>(1 << i);
+    if (counts[i] == max_count && max_count > 0)
+      result |= static_cast<uint8_t>(1 << i);
   }
-  if (intersection) return intersection;
-  uint8_t union_set = 0;
-  for (int i = 0; i < 4; i++) {
-    if (counts[i] > 0) union_set |= static_cast<uint8_t>(1 << i);
-  }
-  return union_set;
+  return result;
 }
 
 // Bottom-up + top-down Fitch pass to assign optimal inner node CGs.
@@ -813,8 +824,7 @@ inline uint8_t fitch_set_from_counts(std::array<uint32_t, 4> const& counts,
 // prefers the parent CG's state (instead of the reference).  This is
 // used for fragments where the root has a real parent in a larger tree.
 inline void fitch_assign_compact_genomes(
-    phylo_dag& d,
-    compact_genome const* root_parent_cg = nullptr) {
+    phylo_dag& d, compact_genome const* root_parent_cg = nullptr) {
   auto const& ref = get_reference_sequence(d);
   auto ua_idx = get_root_idx(d);
   auto ua_clades = get_clades(d, ua_idx);
@@ -838,7 +848,8 @@ inline void fitch_assign_compact_genomes(
         [&](auto node) {
           if constexpr (requires { node.cg(); }) {
             for (auto& [pos, base] : node.cg()) var_sites_set.insert(pos);
-            for (auto pos : node.cg().ambiguity_mask()) var_sites_set.insert(pos);
+            for (auto [pos, state_set] : node.cg().ambiguity_sets())
+              var_sites_set.insert(pos);
           }
         },
         nv);
@@ -847,7 +858,8 @@ inline void fitch_assign_compact_genomes(
   // mutations at sites that are invariant within the fragment.
   if (root_parent_cg) {
     for (auto& [pos, base] : *root_parent_cg) var_sites_set.insert(pos);
-    for (auto pos : root_parent_cg->ambiguity_mask()) var_sites_set.insert(pos);
+    for (auto [pos, state_set] : root_parent_cg->ambiguity_sets())
+      var_sites_set.insert(pos);
   }
   std::pmr::vector<std::size_t> var_sites(var_sites_set.begin(),
                                           var_sites_set.end(), fitch_mr);
@@ -884,9 +896,7 @@ inline void fitch_assign_compact_genomes(
             if constexpr (requires { node.cg(); }) {
               for (std::size_t i = 0; i < n_sites; i++) {
                 auto pos = static_cast<mutation_position>(var_sites[i]);
-                fitch[nid * n_sites + i] = node.cg().is_ambiguous(pos)
-                    ? static_cast<uint8_t>(0b1111)
-                    : base_to_one_hot(node.cg().get_base(pos, ref));
+                fitch[nid * n_sites + i] = node.cg().get_state_set(pos, ref);
               }
             }
           },
@@ -914,21 +924,20 @@ inline void fitch_assign_compact_genomes(
   std::vector<nuc_base> assigned(num_nodes * n_sites);
 
   // Assign tree root: pick base from Fitch set, preferring the parent's
-  // state.  When root_parent_cg is provided (fragment case), use the parent
-  // CG's base; otherwise fall back to the reference base.
+  // compatible state(s).  When root_parent_cg is provided (fragment case), use
+  // the parent CG's exact state set; otherwise fall back to the reference base.
   for (std::size_t i = 0; i < n_sites; i++) {
     uint8_t fs = fitch[tree_root * n_sites + i];
-    nuc_base prefer_base = root_parent_cg
-        ? root_parent_cg->get_base(var_sites[i], ref)
-        : nuc_base::from_char(ref.at(var_sites[i] - 1));
-    if (fs & base_to_one_hot(prefer_base)) {
-      assigned[tree_root * n_sites + i] = prefer_base;
-    } else {
-      for (int j = 0; j < 4; j++) {
-        if (fs & (1 << j)) {
-          assigned[tree_root * n_sites + i] = nuc_base{static_cast<uint8_t>(j)};
-          break;
-        }
+    uint8_t prefer_set =
+        root_parent_cg
+            ? root_parent_cg->get_state_set(var_sites[i], ref)
+            : base_to_one_hot(nuc_base::from_char(ref.at(var_sites[i] - 1)));
+    uint8_t choices = fs & prefer_set;
+    if (choices == 0) choices = fs;
+    for (int j = 0; j < 4; j++) {
+      if (choices & (1 << j)) {
+        assigned[tree_root * n_sites + i] = nuc_base{static_cast<uint8_t>(j)};
+        break;
       }
     }
   }

--- a/include/larch/compute.hpp
+++ b/include/larch/compute.hpp
@@ -90,8 +90,7 @@ inline void recompute_compact_genomes(phylo_dag& d) {
                       pe.get_parent());
 
                   if constexpr (requires { node.cg(); }) {
-                    std::map<mutation_position, uint8_t>
-                        existing_ambiguity_sets;
+                    ambiguity_set_map existing_ambiguity_sets;
                     bool leaf_node = true;
                     for (auto ce : node.get_children()) {
                       (void)ce;

--- a/include/larch/compute.hpp
+++ b/include/larch/compute.hpp
@@ -13,6 +13,7 @@
 #include <map>
 #include <memory_resource>
 #include <queue>
+#include <ranges>
 #include <set>
 #include <sstream>
 #include <stdexcept>
@@ -91,12 +92,7 @@ inline void recompute_compact_genomes(phylo_dag& d) {
 
                   if constexpr (requires { node.cg(); }) {
                     ambiguity_set_map existing_ambiguity_sets;
-                    bool leaf_node = true;
-                    for (auto ce : node.get_children()) {
-                      (void)ce;
-                      leaf_node = false;
-                      break;
-                    }
+                    bool leaf_node = std::ranges::empty(node.get_children());
                     if (leaf_node)
                       existing_ambiguity_sets = node.cg().ambiguity_sets();
                     node.cg() = compact_genome{};

--- a/include/larch/compute.hpp
+++ b/include/larch/compute.hpp
@@ -89,8 +89,17 @@ inline void recompute_compact_genomes(phylo_dag& d) {
                       pe.get_parent());
 
                   if constexpr (requires { node.cg(); }) {
+                    std::set<mutation_position> existing_mask;
+                    bool leaf_node = true;
+                    for (auto ce : node.get_children()) {
+                      (void)ce;
+                      leaf_node = false;
+                      break;
+                    }
+                    if (leaf_node) existing_mask = node.cg().ambiguity_mask();
                     node.cg() = compact_genome{};
                     node.cg().add_parent_edge(edge_muts, parent_cg, ref);
+                    if (leaf_node) node.cg().set_ambiguity_mask(std::move(existing_mask));
                   }
                   cg_set = true;
                 },
@@ -829,6 +838,7 @@ inline void fitch_assign_compact_genomes(
         [&](auto node) {
           if constexpr (requires { node.cg(); }) {
             for (auto& [pos, base] : node.cg()) var_sites_set.insert(pos);
+            for (auto pos : node.cg().ambiguity_mask()) var_sites_set.insert(pos);
           }
         },
         nv);
@@ -837,6 +847,7 @@ inline void fitch_assign_compact_genomes(
   // mutations at sites that are invariant within the fragment.
   if (root_parent_cg) {
     for (auto& [pos, base] : *root_parent_cg) var_sites_set.insert(pos);
+    for (auto pos : root_parent_cg->ambiguity_mask()) var_sites_set.insert(pos);
   }
   std::pmr::vector<std::size_t> var_sites(var_sites_set.begin(),
                                           var_sites_set.end(), fitch_mr);
@@ -871,9 +882,12 @@ inline void fitch_assign_compact_genomes(
       std::visit(
           [&](auto node) {
             if constexpr (requires { node.cg(); }) {
-              for (std::size_t i = 0; i < n_sites; i++)
-                fitch[nid * n_sites + i] =
-                    base_to_one_hot(node.cg().get_base(var_sites[i], ref));
+              for (std::size_t i = 0; i < n_sites; i++) {
+                auto pos = static_cast<mutation_position>(var_sites[i]);
+                fitch[nid * n_sites + i] = node.cg().is_ambiguous(pos)
+                    ? static_cast<uint8_t>(0b1111)
+                    : base_to_one_hot(node.cg().get_base(pos, ref));
+              }
             }
           },
           nv);

--- a/include/larch/load_parsimony.hpp
+++ b/include/larch/load_parsimony.hpp
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <optional>
+#include <set>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -27,6 +28,7 @@ struct pars_mut {
 
 struct pars_mutation_list {
   std::vector<pars_mut> mutation;
+  std::vector<int32_t> ambiguous_sites;
 };
 
 struct pars_condensed_node {
@@ -122,12 +124,18 @@ inline phylo_dag load_parsimony_tree(std::string_view path,
     edge.clade_index() = 0;
   }
 
-  // Apply mutations in preorder
-  // node_mutations are in preorder traversal order of the newick tree
+  // Apply mutations in preorder.
+  // node_mutations are in preorder traversal order of the newick tree.
+  std::unordered_map<std::size_t, std::set<mutation_position>> ambiguity_masks;
   std::size_t muts_idx = 0;
   auto apply_muts = [&](auto& self, std::size_t dag_idx) -> void {
     if (muts_idx >= msg.node_mutations.size()) return;
     auto& ml = msg.node_mutations[muts_idx++];
+    if (!ml.ambiguous_sites.empty()) {
+      auto& mask = ambiguity_masks[dag_idx];
+      for (auto pos : ml.ambiguous_sites)
+        mask.insert(static_cast<mutation_position>(pos));
+    }
 
     std::visit(
         [&](auto node) {
@@ -225,6 +233,16 @@ inline phylo_dag load_parsimony_tree(std::string_view path,
   }
 
   recompute_compact_genomes(d);
+
+  for (auto& [dag_idx, mask] : ambiguity_masks) {
+    std::visit(
+        [&](auto node) {
+          if constexpr (requires { node.cg(); }) {
+            node.cg().set_ambiguity_mask(std::move(mask));
+          }
+        },
+        d.get_node(dag_idx));
+  }
 
   for (auto nv : d.get_all_nodes()) {
     std::visit(

--- a/include/larch/load_parsimony.hpp
+++ b/include/larch/load_parsimony.hpp
@@ -26,9 +26,15 @@ struct pars_mut {
   std::string chromosome;
 };
 
+struct pars_iupac_site {
+  int32_t position;
+  int32_t state_set;
+};
+
 struct pars_mutation_list {
   std::vector<pars_mut> mutation;
   std::vector<int32_t> ambiguous_sites;
+  std::vector<pars_iupac_site> iupac_sites;
 };
 
 struct pars_condensed_node {
@@ -126,15 +132,23 @@ inline phylo_dag load_parsimony_tree(std::string_view path,
 
   // Apply mutations in preorder.
   // node_mutations are in preorder traversal order of the newick tree.
-  std::unordered_map<std::size_t, std::set<mutation_position>> ambiguity_masks;
+  std::unordered_map<std::size_t, std::map<mutation_position, uint8_t>>
+      ambiguity_sets_by_node;
   std::size_t muts_idx = 0;
   auto apply_muts = [&](auto& self, std::size_t dag_idx) -> void {
     if (muts_idx >= msg.node_mutations.size()) return;
     auto& ml = msg.node_mutations[muts_idx++];
     if (!ml.ambiguous_sites.empty()) {
-      auto& mask = ambiguity_masks[dag_idx];
+      auto& ambiguity_sets = ambiguity_sets_by_node[dag_idx];
       for (auto pos : ml.ambiguous_sites)
-        mask.insert(static_cast<mutation_position>(pos));
+        ambiguity_sets[static_cast<mutation_position>(pos)] = 0b1111;
+    }
+    for (auto const& site : ml.iupac_sites) {
+      auto state_set = static_cast<uint8_t>(site.state_set) & 0b1111;
+      if (state_set != 0) {
+        ambiguity_sets_by_node[dag_idx][static_cast<mutation_position>(
+            site.position)] = state_set;
+      }
     }
 
     std::visit(
@@ -234,11 +248,11 @@ inline phylo_dag load_parsimony_tree(std::string_view path,
 
   recompute_compact_genomes(d);
 
-  for (auto& [dag_idx, mask] : ambiguity_masks) {
+  for (auto& [dag_idx, ambiguity_sets] : ambiguity_sets_by_node) {
     std::visit(
         [&](auto node) {
           if constexpr (requires { node.cg(); }) {
-            node.cg().set_ambiguity_mask(std::move(mask));
+            node.cg().set_ambiguity_sets(std::move(ambiguity_sets));
           }
         },
         d.get_node(dag_idx));

--- a/include/larch/load_parsimony.hpp
+++ b/include/larch/load_parsimony.hpp
@@ -132,8 +132,7 @@ inline phylo_dag load_parsimony_tree(std::string_view path,
 
   // Apply mutations in preorder.
   // node_mutations are in preorder traversal order of the newick tree.
-  std::unordered_map<std::size_t, std::map<mutation_position, uint8_t>>
-      ambiguity_sets_by_node;
+  std::unordered_map<std::size_t, ambiguity_set_map> ambiguity_sets_by_node;
   std::size_t muts_idx = 0;
   auto apply_muts = [&](auto& self, std::size_t dag_idx) -> void {
     if (muts_idx >= msg.node_mutations.size()) return;

--- a/include/larch/load_proto_dag.hpp
+++ b/include/larch/load_proto_dag.hpp
@@ -234,7 +234,7 @@ inline phylo_dag load_proto_dag(std::string_view path) {
 
   recompute_compact_genomes(d);
 
-  for (auto [proto_id, ambiguity_sets] : node_ambiguity_sets) {
+  for (auto& [proto_id, ambiguity_sets] : node_ambiguity_sets) {
     auto it = proto_to_dag.find(proto_id);
     if (it == proto_to_dag.end()) continue;
     auto dag_idx = it->second;

--- a/include/larch/load_proto_dag.hpp
+++ b/include/larch/load_proto_dag.hpp
@@ -6,6 +6,7 @@
 #include <larch/thread_pool.hpp>
 
 #include <algorithm>
+#include <map>
 #include <numeric>
 #include <optional>
 #include <set>
@@ -35,10 +36,16 @@ struct dag_edge {
   float edge_weight;
 };
 
+struct iupac_site {
+  int32_t position;
+  int32_t state_set;
+};
+
 struct dag_node_name {
   int64_t node_id;
   std::vector<std::string> condensed_leaves;
   std::vector<int32_t> ambiguous_sites;
+  std::vector<iupac_site> iupac_sites;
 };
 
 struct dag_data {
@@ -113,17 +120,24 @@ inline phylo_dag load_proto_dag(std::string_view path) {
   scoped_arena<32768> arena;
   auto* mr = arena.get();
   std::pmr::unordered_map<std::size_t, std::string> node_sample_ids(mr);
-  std::pmr::unordered_map<std::size_t, std::set<mutation_position>>
-      node_ambiguity_masks(mr);
+  std::pmr::unordered_map<std::size_t, std::map<mutation_position, uint8_t>>
+      node_ambiguity_sets(mr);
   for (auto& nn : meta.node_names) {
     auto node_id = static_cast<std::size_t>(nn.node_id);
     if (!nn.condensed_leaves.empty()) {
       node_sample_ids[node_id] = nn.condensed_leaves[0];
     }
     if (!nn.ambiguous_sites.empty()) {
-      auto& mask = node_ambiguity_masks[node_id];
+      auto& sets = node_ambiguity_sets[node_id];
       for (auto pos : nn.ambiguous_sites)
-        mask.insert(static_cast<mutation_position>(pos));
+        sets[static_cast<mutation_position>(pos)] = 0b1111;
+    }
+    for (auto const& site : nn.iupac_sites) {
+      auto state_set = static_cast<uint8_t>(site.state_set) & 0b1111;
+      if (state_set != 0) {
+        node_ambiguity_sets[node_id][static_cast<mutation_position>(
+            site.position)] = state_set;
+      }
     }
   }
 
@@ -220,14 +234,14 @@ inline phylo_dag load_proto_dag(std::string_view path) {
 
   recompute_compact_genomes(d);
 
-  for (auto [proto_id, mask] : node_ambiguity_masks) {
+  for (auto [proto_id, ambiguity_sets] : node_ambiguity_sets) {
     auto it = proto_to_dag.find(proto_id);
     if (it == proto_to_dag.end()) continue;
     auto dag_idx = it->second;
     std::visit(
         [&](auto node) {
           if constexpr (requires { node.cg(); }) {
-            node.cg().set_ambiguity_mask(std::move(mask));
+            node.cg().set_ambiguity_sets(std::move(ambiguity_sets));
           }
         },
         d.get_node(dag_idx));

--- a/include/larch/load_proto_dag.hpp
+++ b/include/larch/load_proto_dag.hpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <numeric>
 #include <optional>
+#include <set>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -37,6 +38,7 @@ struct dag_edge {
 struct dag_node_name {
   int64_t node_id;
   std::vector<std::string> condensed_leaves;
+  std::vector<int32_t> ambiguous_sites;
 };
 
 struct dag_data {
@@ -111,10 +113,17 @@ inline phylo_dag load_proto_dag(std::string_view path) {
   scoped_arena<32768> arena;
   auto* mr = arena.get();
   std::pmr::unordered_map<std::size_t, std::string> node_sample_ids(mr);
+  std::pmr::unordered_map<std::size_t, std::set<mutation_position>>
+      node_ambiguity_masks(mr);
   for (auto& nn : meta.node_names) {
+    auto node_id = static_cast<std::size_t>(nn.node_id);
     if (!nn.condensed_leaves.empty()) {
-      node_sample_ids[static_cast<std::size_t>(nn.node_id)] =
-          nn.condensed_leaves[0];
+      node_sample_ids[node_id] = nn.condensed_leaves[0];
+    }
+    if (!nn.ambiguous_sites.empty()) {
+      auto& mask = node_ambiguity_masks[node_id];
+      for (auto pos : nn.ambiguous_sites)
+        mask.insert(static_cast<mutation_position>(pos));
     }
   }
 
@@ -210,6 +219,19 @@ inline phylo_dag load_proto_dag(std::string_view path) {
   }
 
   recompute_compact_genomes(d);
+
+  for (auto [proto_id, mask] : node_ambiguity_masks) {
+    auto it = proto_to_dag.find(proto_id);
+    if (it == proto_to_dag.end()) continue;
+    auto dag_idx = it->second;
+    std::visit(
+        [&](auto node) {
+          if constexpr (requires { node.cg(); }) {
+            node.cg().set_ambiguity_mask(std::move(mask));
+          }
+        },
+        d.get_node(dag_idx));
+  }
 
   // Set sample IDs for leaves without one.
   // Use CG string as base, but disambiguate duplicates so that

--- a/include/larch/load_proto_dag.hpp
+++ b/include/larch/load_proto_dag.hpp
@@ -120,7 +120,7 @@ inline phylo_dag load_proto_dag(std::string_view path) {
   scoped_arena<32768> arena;
   auto* mr = arena.get();
   std::pmr::unordered_map<std::size_t, std::string> node_sample_ids(mr);
-  std::pmr::unordered_map<std::size_t, std::map<mutation_position, uint8_t>>
+  std::pmr::unordered_map<std::size_t, ambiguity_set_map>
       node_ambiguity_sets(mr);
   for (auto& nn : meta.node_names) {
     auto node_id = static_cast<std::size_t>(nn.node_id);

--- a/include/larch/native_optimize.hpp
+++ b/include/larch/native_optimize.hpp
@@ -715,6 +715,16 @@ class tree_index {
           },
           ev);
     }
+    for (auto nv : d_.get_all_nodes()) {
+      std::visit(
+          [&](auto node) {
+            if constexpr (requires { node.cg(); }) {
+              for (auto& [pos, base] : node.cg()) var_sites_set.insert(pos);
+              for (auto pos : node.cg().ambiguity_mask()) var_sites_set.insert(pos);
+            }
+          },
+          nv);
+    }
     for (auto site : var_sites_set) variable_sites_.push_back(site);
     num_variable_sites_ = variable_sites_.size();
 
@@ -804,16 +814,17 @@ class tree_index {
     compute_fitch_sets();
   }
 
-  nuc_base get_node_base(std::size_t nid, std::size_t site,
-                         std::string const& ref) {
+  uint8_t get_node_fitch_set(std::size_t nid, std::size_t site,
+                             std::string const& ref) {
     auto nv = d_.get_node(nid);
-    nuc_base result;
+    uint8_t result = base_to_one_hot(nuc_base::from_char(ref.at(site - 1)));
     std::visit(
         [&](auto node) {
           if constexpr (requires { node.cg(); }) {
-            result = node.cg().get_base(site, ref);
-          } else {
-            result = nuc_base::from_char(ref.at(site - 1));
+            auto pos = static_cast<mutation_position>(site);
+            result = node.cg().is_ambiguous(pos)
+                ? static_cast<uint8_t>(0b1111)
+                : base_to_one_hot(node.cg().get_base(pos, ref));
           }
         },
         nv);
@@ -989,10 +1000,9 @@ class tree_index {
 
     if (is_leaf(d_, node_id)) {
       for (std::size_t i = 0; i < num_variable_sites_; i++) {
-        auto base = get_node_base(node_id, variable_sites_[i], ref);
-        uint8_t singleton = base_to_one_hot(base);
-        fitch_sets_[base_offset + i] = singleton;
-        allele_union_[base_offset + i] = singleton;
+        uint8_t fset = get_node_fitch_set(node_id, variable_sites_[i], ref);
+        fitch_sets_[base_offset + i] = fset;
+        allele_union_[base_offset + i] = fset;
       }
     } else {
       auto& children = children_[node_id];
@@ -1032,10 +1042,9 @@ class tree_index {
 
     if (is_leaf(d_, node_id)) {
       for (std::size_t i = 0; i < num_variable_sites_; i++) {
-        auto base = get_node_base(node_id, variable_sites_[i], ref);
-        uint8_t singleton = base_to_one_hot(base);
-        fitch_sets_[base_offset + i] = singleton;
-        allele_union_[base_offset + i] = singleton;
+        uint8_t fset = get_node_fitch_set(node_id, variable_sites_[i], ref);
+        fitch_sets_[base_offset + i] = fset;
+        allele_union_[base_offset + i] = fset;
       }
       co_return;
     }

--- a/include/larch/native_optimize.hpp
+++ b/include/larch/native_optimize.hpp
@@ -83,10 +83,14 @@ struct scratch_buffers {
 inline int fitch_cost_from_counts(std::array<uint32_t, 4> const& counts,
                                   uint32_t num_children) {
   if (num_children <= 1) return 0;
-  for (int i = 0; i < 4; i++) {
-    if (counts[i] == num_children) return 0;
-  }
-  return 1;
+
+  // Generalized Fitch/Sankoff for polytomies and ambiguous child state sets:
+  // assigning this node to base b costs one change for each child whose
+  // optimal state set excludes b.  Minimize that cost by choosing a base with
+  // maximum child support.
+  uint32_t max_count = 0;
+  for (auto count : counts) max_count = std::max(max_count, count);
+  return static_cast<int>(num_children - max_count);
 }
 
 inline std::size_t compute_tree_max_depth(phylo_dag& d) {
@@ -720,7 +724,8 @@ class tree_index {
           [&](auto node) {
             if constexpr (requires { node.cg(); }) {
               for (auto& [pos, base] : node.cg()) var_sites_set.insert(pos);
-              for (auto pos : node.cg().ambiguity_mask()) var_sites_set.insert(pos);
+              for (auto [pos, state_set] : node.cg().ambiguity_sets())
+                var_sites_set.insert(pos);
             }
           },
           nv);
@@ -822,9 +827,7 @@ class tree_index {
         [&](auto node) {
           if constexpr (requires { node.cg(); }) {
             auto pos = static_cast<mutation_position>(site);
-            result = node.cg().is_ambiguous(pos)
-                ? static_cast<uint8_t>(0b1111)
-                : base_to_one_hot(node.cg().get_base(pos, ref));
+            result = node.cg().get_state_set(pos, ref);
           }
         },
         nv);

--- a/include/larch/save_proto_dag.hpp
+++ b/include/larch/save_proto_dag.hpp
@@ -69,6 +69,10 @@ inline void save_proto_dag(phylo_dag& dag, std::string_view path,
           if constexpr (requires { node.sample_id(); }) {
             nn.condensed_leaves = {node.sample_id()};
           }
+          if constexpr (requires { node.cg(); }) {
+            for (auto pos : node.cg().ambiguity_mask())
+              nn.ambiguous_sites.push_back(static_cast<int32_t>(pos));
+          }
           data.node_names.push_back(std::move(nn));
         },
         nv);

--- a/include/larch/save_proto_dag.hpp
+++ b/include/larch/save_proto_dag.hpp
@@ -70,8 +70,12 @@ inline void save_proto_dag(phylo_dag& dag, std::string_view path,
             nn.condensed_leaves = {node.sample_id()};
           }
           if constexpr (requires { node.cg(); }) {
-            for (auto pos : node.cg().ambiguity_mask())
-              nn.ambiguous_sites.push_back(static_cast<int32_t>(pos));
+            for (auto [pos, state_set] : node.cg().ambiguity_sets()) {
+              nn.iupac_sites.push_back({static_cast<int32_t>(pos),
+                                        static_cast<int32_t>(state_set)});
+              if ((state_set & 0b1111) == 0b1111)
+                nn.ambiguous_sites.push_back(static_cast<int32_t>(pos));
+            }
           }
           data.node_names.push_back(std::move(nn));
         },

--- a/include/larch/save_proto_dag.hpp
+++ b/include/larch/save_proto_dag.hpp
@@ -71,8 +71,10 @@ inline void save_proto_dag(phylo_dag& dag, std::string_view path,
           }
           if constexpr (requires { node.cg(); }) {
             for (auto [pos, state_set] : node.cg().ambiguity_sets()) {
-              nn.iupac_sites.push_back({static_cast<int32_t>(pos),
-                                        static_cast<int32_t>(state_set)});
+              nn.iupac_sites.push_back(iupac_site{
+                  .position = static_cast<int32_t>(pos),
+                  .state_set = static_cast<int32_t>(state_set),
+              });
               if ((state_set & 0b1111) == 0b1111)
                 nn.ambiguous_sites.push_back(static_cast<int32_t>(pos));
             }

--- a/include/larch/vcf.hpp
+++ b/include/larch/vcf.hpp
@@ -6,7 +6,6 @@
 #include <larch/nuc.hpp>
 
 #include <charconv>
-#include <iostream>
 #include <map>
 #include <set>
 #include <string>
@@ -18,6 +17,7 @@ namespace larch {
 struct vcf_data {
   std::vector<std::string> sample_names;
   std::map<std::string, compact_genome> sample_genomes;
+  ambiguity_counts ambiguity;
 };
 
 inline vcf_data read_vcf(std::string_view path, std::string_view reference) {
@@ -29,7 +29,7 @@ inline vcf_data read_vcf(std::string_view path, std::string_view reference) {
   // at end.
   std::map<std::string, std::map<mutation_position, nuc_base>> sample_muts;
   std::map<std::string, ambiguity_set_map> sample_ambiguity;
-  ambiguity_counts ambiguity;
+  auto& ambiguity = result.ambiguity;
 
   std::size_t pos = 0;
   while (pos < content.size()) {
@@ -125,8 +125,6 @@ inline vcf_data read_vcf(std::string_view path, std::string_view reference) {
       }
     }
   }
-
-  warn_if_ambiguities(ambiguity, "VCF genotypes");
 
   // Convert accumulated mutations/IUPAC state sets to compact_genomes.
   for (auto& [name, muts] : sample_muts) {

--- a/include/larch/vcf.hpp
+++ b/include/larch/vcf.hpp
@@ -28,7 +28,7 @@ inline vcf_data read_vcf(std::string_view path, std::string_view reference) {
   // Accumulate per-sample mutations/IUPAC state sets, convert to compact_genome
   // at end.
   std::map<std::string, std::map<mutation_position, nuc_base>> sample_muts;
-  std::map<std::string, std::map<mutation_position, uint8_t>> sample_ambiguity;
+  std::map<std::string, ambiguity_set_map> sample_ambiguity;
   ambiguity_counts ambiguity;
 
   std::size_t pos = 0;
@@ -131,7 +131,7 @@ inline vcf_data read_vcf(std::string_view path, std::string_view reference) {
   // Convert accumulated mutations/IUPAC state sets to compact_genomes.
   for (auto& [name, muts] : sample_muts) {
     auto amb_it = sample_ambiguity.find(name);
-    std::map<mutation_position, uint8_t> ambiguity_sets;
+    ambiguity_set_map ambiguity_sets;
     if (amb_it != sample_ambiguity.end())
       ambiguity_sets = std::move(amb_it->second);
     result.sample_genomes[name] =
@@ -164,8 +164,7 @@ inline void apply_vcf_to_dag(phylo_dag& d, vcf_data const& vcf) {
             // concrete calls, then apply VCF IUPAC state sets.
             std::map<mutation_position, nuc_base> muts;
             for (auto [pos, base] : node.cg()) muts[pos] = base;
-            std::map<mutation_position, uint8_t> ambiguity_sets =
-                node.cg().ambiguity_sets();
+            ambiguity_set_map ambiguity_sets = node.cg().ambiguity_sets();
             for (auto [pos, base] : it->second) {
               ambiguity_sets.erase(pos);
               auto ref_base = nuc_base::from_char(ref.at(pos - 1));

--- a/include/larch/vcf.hpp
+++ b/include/larch/vcf.hpp
@@ -6,7 +6,9 @@
 #include <larch/nuc.hpp>
 
 #include <charconv>
+#include <iostream>
 #include <map>
+#include <set>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -23,8 +25,10 @@ inline vcf_data read_vcf(std::string_view path, std::string_view reference) {
   std::string_view content{bytes.data(), bytes.size()};
 
   vcf_data result;
-  // Accumulate per-sample mutations, convert to compact_genome at end
+  // Accumulate per-sample mutations/no-calls, convert to compact_genome at end.
   std::map<std::string, std::map<mutation_position, nuc_base>> sample_muts;
+  std::map<std::string, std::set<mutation_position>> sample_masks;
+  ambiguity_counts ambiguity;
 
   std::size_t pos = 0;
   while (pos < content.size()) {
@@ -96,23 +100,45 @@ inline vcf_data read_vcf(std::string_view path, std::string_view reference) {
       int allele_idx = 0;
       if (!gt.empty() && gt[0] >= '0' && gt[0] <= '9') allele_idx = gt[0] - '0';
 
-      nuc_base sample_base = nuc_base::from_char(ref_allele[0]);
+      bool is_ambiguous = is_iupac_ambiguity_char(ref_allele[0]);
+      char allele_char = ref_allele[0];
       if (allele_idx > 0 &&
           static_cast<std::size_t>(allele_idx - 1) < alt_alleles.size()) {
-        sample_base = nuc_base::from_char(alt_alleles[allele_idx - 1][0]);
+        allele_char = alt_alleles[allele_idx - 1][0];
+        is_ambiguous = is_iupac_ambiguity_char(allele_char);
+      }
+
+      ambiguity.observed_sites++;
+      if (is_ambiguous) {
+        sample_muts[result.sample_names[i]].erase(mpos);
+        sample_masks[result.sample_names[i]].insert(mpos);
+        ambiguity.add(allele_char);
+        continue;
       }
 
       // Record mutation if different from reference
+      nuc_base sample_base = nuc_base::from_char(allele_char);
       nuc_base ref_base = nuc_base::from_char(reference.at(mpos - 1));
+      sample_masks[result.sample_names[i]].erase(mpos);
       if (!(sample_base == ref_base)) {
         sample_muts[result.sample_names[i]][mpos] = sample_base;
       }
     }
   }
 
-  // Convert accumulated mutations to compact_genomes
+  warn_if_ambiguities(ambiguity, "VCF genotypes");
+
+  // Convert accumulated mutations/no-calls to compact_genomes.
   for (auto& [name, muts] : sample_muts) {
-    result.sample_genomes[name] = compact_genome{std::move(muts)};
+    auto mask_it = sample_masks.find(name);
+    std::set<mutation_position> mask;
+    if (mask_it != sample_masks.end()) mask = std::move(mask_it->second);
+    result.sample_genomes[name] = compact_genome{std::move(muts), std::move(mask)};
+  }
+  for (auto& [name, mask] : sample_masks) {
+    if (!result.sample_genomes.contains(name)) {
+      result.sample_genomes[name] = compact_genome{{}, std::move(mask)};
+    }
   }
 
   return result;
@@ -131,17 +157,24 @@ inline void apply_vcf_to_dag(phylo_dag& d, vcf_data const& vcf) {
             auto it = vcf.sample_genomes.find(node.sample_id());
             if (it == vcf.sample_genomes.end()) return;
 
-            // Build new mutations map: start from existing CG, overlay VCF
+            // Build new compact genome: start from existing CG, overlay VCF
+            // concrete calls, then apply VCF no-calls.
             std::map<mutation_position, nuc_base> muts;
             for (auto [pos, base] : node.cg()) muts[pos] = base;
+            std::set<mutation_position> mask = node.cg().ambiguity_mask();
             for (auto [pos, base] : it->second) {
+              mask.erase(pos);
               auto ref_base = nuc_base::from_char(ref.at(pos - 1));
               if (base == ref_base)
                 muts.erase(pos);
               else
                 muts[pos] = base;
             }
-            node.cg() = compact_genome{std::move(muts)};
+            for (auto pos : it->second.ambiguity_mask()) {
+              muts.erase(pos);
+              mask.insert(pos);
+            }
+            node.cg() = compact_genome{std::move(muts), std::move(mask)};
           }
         },
         nv);

--- a/include/larch/vcf.hpp
+++ b/include/larch/vcf.hpp
@@ -25,9 +25,10 @@ inline vcf_data read_vcf(std::string_view path, std::string_view reference) {
   std::string_view content{bytes.data(), bytes.size()};
 
   vcf_data result;
-  // Accumulate per-sample mutations/no-calls, convert to compact_genome at end.
+  // Accumulate per-sample mutations/IUPAC state sets, convert to compact_genome
+  // at end.
   std::map<std::string, std::map<mutation_position, nuc_base>> sample_muts;
-  std::map<std::string, std::set<mutation_position>> sample_masks;
+  std::map<std::string, std::map<mutation_position, uint8_t>> sample_ambiguity;
   ambiguity_counts ambiguity;
 
   std::size_t pos = 0;
@@ -100,18 +101,17 @@ inline vcf_data read_vcf(std::string_view path, std::string_view reference) {
       int allele_idx = 0;
       if (!gt.empty() && gt[0] >= '0' && gt[0] <= '9') allele_idx = gt[0] - '0';
 
-      bool is_ambiguous = is_iupac_ambiguity_char(ref_allele[0]);
       char allele_char = ref_allele[0];
       if (allele_idx > 0 &&
           static_cast<std::size_t>(allele_idx - 1) < alt_alleles.size()) {
         allele_char = alt_alleles[allele_idx - 1][0];
-        is_ambiguous = is_iupac_ambiguity_char(allele_char);
       }
+      auto state_set = iupac_state_set(allele_char);
 
       ambiguity.observed_sites++;
-      if (is_ambiguous) {
+      if (state_set != 0 && std::popcount(state_set) != 1) {
         sample_muts[result.sample_names[i]].erase(mpos);
-        sample_masks[result.sample_names[i]].insert(mpos);
+        sample_ambiguity[result.sample_names[i]][mpos] = state_set;
         ambiguity.add(allele_char);
         continue;
       }
@@ -119,7 +119,7 @@ inline vcf_data read_vcf(std::string_view path, std::string_view reference) {
       // Record mutation if different from reference
       nuc_base sample_base = nuc_base::from_char(allele_char);
       nuc_base ref_base = nuc_base::from_char(reference.at(mpos - 1));
-      sample_masks[result.sample_names[i]].erase(mpos);
+      sample_ambiguity[result.sample_names[i]].erase(mpos);
       if (!(sample_base == ref_base)) {
         sample_muts[result.sample_names[i]][mpos] = sample_base;
       }
@@ -128,16 +128,19 @@ inline vcf_data read_vcf(std::string_view path, std::string_view reference) {
 
   warn_if_ambiguities(ambiguity, "VCF genotypes");
 
-  // Convert accumulated mutations/no-calls to compact_genomes.
+  // Convert accumulated mutations/IUPAC state sets to compact_genomes.
   for (auto& [name, muts] : sample_muts) {
-    auto mask_it = sample_masks.find(name);
-    std::set<mutation_position> mask;
-    if (mask_it != sample_masks.end()) mask = std::move(mask_it->second);
-    result.sample_genomes[name] = compact_genome{std::move(muts), std::move(mask)};
+    auto amb_it = sample_ambiguity.find(name);
+    std::map<mutation_position, uint8_t> ambiguity_sets;
+    if (amb_it != sample_ambiguity.end())
+      ambiguity_sets = std::move(amb_it->second);
+    result.sample_genomes[name] =
+        compact_genome{std::move(muts), std::move(ambiguity_sets)};
   }
-  for (auto& [name, mask] : sample_masks) {
+  for (auto& [name, ambiguity_sets] : sample_ambiguity) {
     if (!result.sample_genomes.contains(name)) {
-      result.sample_genomes[name] = compact_genome{{}, std::move(mask)};
+      result.sample_genomes[name] =
+          compact_genome{{}, std::move(ambiguity_sets)};
     }
   }
 
@@ -158,23 +161,25 @@ inline void apply_vcf_to_dag(phylo_dag& d, vcf_data const& vcf) {
             if (it == vcf.sample_genomes.end()) return;
 
             // Build new compact genome: start from existing CG, overlay VCF
-            // concrete calls, then apply VCF no-calls.
+            // concrete calls, then apply VCF IUPAC state sets.
             std::map<mutation_position, nuc_base> muts;
             for (auto [pos, base] : node.cg()) muts[pos] = base;
-            std::set<mutation_position> mask = node.cg().ambiguity_mask();
+            std::map<mutation_position, uint8_t> ambiguity_sets =
+                node.cg().ambiguity_sets();
             for (auto [pos, base] : it->second) {
-              mask.erase(pos);
+              ambiguity_sets.erase(pos);
               auto ref_base = nuc_base::from_char(ref.at(pos - 1));
               if (base == ref_base)
                 muts.erase(pos);
               else
                 muts[pos] = base;
             }
-            for (auto pos : it->second.ambiguity_mask()) {
+            for (auto [pos, state_set] : it->second.ambiguity_sets()) {
               muts.erase(pos);
-              mask.insert(pos);
+              ambiguity_sets[pos] = state_set;
             }
-            node.cg() = compact_genome{std::move(muts), std::move(mask)};
+            node.cg() =
+                compact_genome{std::move(muts), std::move(ambiguity_sets)};
           }
         },
         nv);

--- a/proto/dag.proto
+++ b/proto/dag.proto
@@ -28,6 +28,7 @@ message edge {
 message node_name {
     int64 node_id = 1; // The node name as given in the edges from the DAG
     repeated string condensed_leaves = 2; // A list of strings for the names of the sequence/sequences which are represented by the node above. can be just one if a leaf is unique. 
+    repeated int32 ambiguous_sites = 3; // 1-indexed leaf no-call sites (IUPAC ambiguity/gap in original alignment)
 }
 
 /// removed the newick since the DAG will have nodes that cannot be represented within a single tree anyway.  

--- a/proto/dag.proto
+++ b/proto/dag.proto
@@ -23,12 +23,18 @@ message edge {
     float edge_weight = 6; // e.g., if you want to attach a probability to an individual edge. Might not be needed for a bare-bones version of this. Can also add other fields.  
 }
 
+message ambiguous_site {
+    int32 position = 1;
+    int32 state_set = 2; // bitmask A=1,C=2,G=4,T=8
+}
+
 /// sample IDs linked to the integer node representation in the DAG
 /// this might also be modified to include an idea of node metadata, e.g., sample dates
 message node_name {
     int64 node_id = 1; // The node name as given in the edges from the DAG
     repeated string condensed_leaves = 2; // A list of strings for the names of the sequence/sequences which are represented by the node above. can be just one if a leaf is unique. 
-    repeated int32 ambiguous_sites = 3; // 1-indexed leaf no-call sites (IUPAC ambiguity/gap in original alignment)
+    repeated int32 ambiguous_sites = 3; // legacy 1-indexed leaf no-call sites (N/gap/? or older all-IUPAC-as-no-call builds)
+    repeated ambiguous_site iupac_sites = 4; // exact IUPAC state-set sites
 }
 
 /// removed the newick since the DAG will have nodes that cannot be represented within a single tree anyway.  

--- a/proto/parsimony.proto
+++ b/proto/parsimony.proto
@@ -10,9 +10,15 @@ message mut {
     string chromosome = 5; // Chromosome string. Currently unused.
 }
 
+message ambiguous_site {
+    int32 position = 1;
+    int32 state_set = 2; // bitmask A=1,C=2,G=4,T=8
+}
+
 message mutation_list {
     repeated mut mutation = 1;
-    repeated int32 ambiguous_sites = 2; // 1-indexed leaf no-call sites (IUPAC ambiguity/gap in original alignment)
+    repeated int32 ambiguous_sites = 2; // legacy 1-indexed leaf no-call sites (N/gap/? or older all-IUPAC-as-no-call builds)
+    repeated ambiguous_site iupac_sites = 3; // exact IUPAC state-set sites
 }
 
 message condensed_node {

--- a/proto/parsimony.proto
+++ b/proto/parsimony.proto
@@ -12,6 +12,7 @@ message mut {
 
 message mutation_list {
     repeated mut mutation = 1;
+    repeated int32 ambiguous_sites = 2; // 1-indexed leaf no-call sites (IUPAC ambiguity/gap in original alignment)
 }
 
 message condensed_node {

--- a/test/inplace_spr_test.cpp
+++ b/test/inplace_spr_test.cpp
@@ -4,6 +4,7 @@
 #include <larch/subtree_weight.hpp>
 #include <larch/simple_weight_ops.hpp>
 
+#include <array>
 #include <cassert>
 #include <map>
 #include <print>
@@ -4370,27 +4371,29 @@ static void test_single_node_fitch_new_child() {
   // Now I has 3 children: {A, B, C}.
   assert(idx.get_num_children(I) == 3);
 
-  // fitch_set_from_counts uses intersection/union:
-  //   - intersection = bases present in ALL children
-  //   - if intersection non-empty → return intersection, else return union
+  // fitch_set_from_counts uses the generalized Fitch/Sankoff rule for
+  // multifurcations: the parent state set is the set of bases tied for maximum
+  // child support.
   //
   // With 3 children {A, B, C}:
-  // Site 0 (pos 1): A=T, B=A, C=A → counts: A=2,T=1 → no base in all 3 → union={A,T}
-  // Site 1 (pos 2): A=A, B=T, C=A → counts: A=2,T=1 → no base in all 3 → union={A,T}
-  // Site 2 (pos 3): A=A, B=A, C=T → counts: A=2,T=1 → no base in all 3 → union={A,T}
+  // Site 0 (pos 1): A=T, B=A, C=A → counts: A=2,T=1 → max={A}
+  // Site 1 (pos 2): A=A, B=T, C=A → counts: A=2,T=1 → max={A}
+  // Site 2 (pos 3): A=A, B=A, C=T → counts: A=2,T=1 → max={A}
   for (std::size_t i = 0; i < nsites; i++) {
-    assert(idx.get_fitch_set(I, i) == (0b0001 | 0b1000));  // {A, T}
+    assert(idx.get_fitch_set(I, i) == 0b0001);  // {A}
   }
 
-  // allele_union should be union of all children's alleles: {A, T} for all sites.
+  // allele_union should still be union of all children's alleles: {A, T} for
+  // all sites.
   for (std::size_t i = 0; i < nsites; i++) {
     assert(idx.get_allele_union(I, i) == (0b0001 | 0b1000));  // {A, T}
   }
 
-  // Site 2 should have changed: was {A} (intersection of A,A with 2 children),
-  // now {A,T} (union, since no base in all 3 children).
-  // Sites 0,1 were already {A,T} with 2 children (no intersection → union).
-  assert(idx.get_fitch_set(I, 2) != fitch_before[2]);
+  // Sites 0 and 1 changed from {A,T} with two children to {A} with three
+  // children. Site 2 was already {A} and remains {A}.
+  assert(idx.get_fitch_set(I, 0) != fitch_before[0]);
+  assert(idx.get_fitch_set(I, 1) != fitch_before[1]);
+  assert(idx.get_fitch_set(I, 2) == fitch_before[2]);
 
   std::println("  PASS");
 }
@@ -5051,7 +5054,8 @@ static void test_update_fitch_insertion_early_termination() {
 // ---------------------------------------------------------------------------
 
 // Helper: verify Fitch self-consistency — every valid inner node's Fitch set
-// must match the standard Fitch rule applied to its children's Fitch sets.
+// must match the generalized Fitch/Sankoff rule applied to its children's
+// Fitch sets.
 static void verify_fitch_self_consistent(tree_index& idx) {
   auto nsites = idx.num_variable_sites();
   auto nnodes = idx.num_nodes();
@@ -5061,14 +5065,15 @@ static void verify_fitch_self_consistent(tree_index& idx) {
     if (children.empty()) continue;  // leaf
 
     for (std::size_t s = 0; s < nsites; s++) {
-      uint8_t intersection = 0xFF;
-      uint8_t union_bits = 0;
+      std::array<uint32_t, 4> counts = {0, 0, 0, 0};
       for (auto child : children) {
         uint8_t cf = idx.get_fitch_set(child, s);
-        intersection &= cf;
-        union_bits |= cf;
+        for (int base = 0; base < 4; base++) {
+          if (cf & (1 << base)) counts[base]++;
+        }
       }
-      uint8_t expected = (intersection != 0) ? intersection : union_bits;
+      uint8_t expected =
+          fitch_set_from_counts(counts, static_cast<uint32_t>(children.size()));
       uint8_t actual = idx.get_fitch_set(nid, s);
       if (actual != expected) {
         std::println("  FAIL: fitch mismatch at node {} site {}: "

--- a/test/iupac_correctness_test.cpp
+++ b/test/iupac_correctness_test.cpp
@@ -1,0 +1,239 @@
+#include <larch/compute.hpp>
+#include <larch/load_parsimony.hpp>
+#include <larch/load_proto_dag.hpp>
+#include <larch/native_optimize.hpp>
+#include <larch/protobuf_encode.hpp>
+#include <larch/save_proto_dag.hpp>
+#include <larch/subtree_weight.hpp>
+#include <larch/vcf.hpp>
+#include <larch/weight_ops.hpp>
+
+#include <array>
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <print>
+#include <set>
+#include <string>
+#include <unordered_set>
+
+using namespace larch;
+
+static compact_genome cg_from_sequence(std::string_view seq,
+                                       std::string_view ref) {
+  return compact_genome_from_sequence(seq, ref);
+}
+
+static void add_edge(phylo_dag& d, std::size_t parent_idx,
+                     std::size_t child_idx, std::size_t clade_idx) {
+  auto edge = d.append_edge<edge_kind::clade>();
+  edge.clade_index() = clade_idx;
+  std::visit([&](auto p) { edge.set_parent(p); }, d.get_node(parent_idx));
+  std::visit([&](auto c) { edge.set_child(c); }, d.get_node(child_idx));
+}
+
+static std::size_t edge_mutation_count(phylo_dag& d) {
+  std::size_t score = 0;
+  for (auto ev : d.get_all_edges()) {
+    std::visit([&](auto e) { score += e.mutations().size(); }, ev);
+  }
+  return score;
+}
+
+static compact_genome leaf_cg(phylo_dag& d, std::string_view sample_id) {
+  compact_genome result;
+  for (auto nv : d.get_all_nodes()) {
+    std::visit(
+        [&](auto node) {
+          if constexpr (requires { node.sample_id(); node.cg(); }) {
+            if (node.sample_id() == sample_id) result = node.cg();
+          }
+        },
+        nv);
+  }
+  return result;
+}
+
+static phylo_dag make_three_leaf_star(std::string_view ref,
+                                      std::string_view a,
+                                      std::string_view b,
+                                      std::string_view c) {
+  phylo_dag d;
+  auto ua = d.append_node<node_kind::ua>();
+  ua.reference_sequence() = std::string{ref};
+  d.set_root(ua);
+
+  auto root = d.append_node<node_kind::inner>();
+  root.cg() = compact_genome{};
+  add_edge(d, ua.index(), root.index(), 0);
+
+  std::array<std::string_view, 3> seqs = {a, b, c};
+  for (std::size_t i = 0; i < seqs.size(); ++i) {
+    auto leaf = d.append_node<node_kind::leaf>();
+    leaf.sample_id() = "L" + std::to_string(i + 1);
+    leaf.cg() = cg_from_sequence(seqs[i], ref);
+    add_edge(d, root.index(), leaf.index(), i);
+  }
+  return d;
+}
+
+static void test_to_edge_mutations_skips_no_call() {
+  std::println("test_to_edge_mutations_skips_no_call");
+
+  compact_genome parent;
+  compact_genome child{{}, {1}};
+  auto muts = compact_genome::to_edge_mutations("C", parent, child);
+
+  assert(muts.empty());
+  std::println("  PASS");
+}
+
+static void test_fitch_no_call_leaf_bitmask() {
+  std::println("test_fitch_no_call_leaf_bitmask");
+
+  // Gold test: with ref A and leaves C/N/C, treating N as concrete A costs 2
+  // (UA->root plus one child conflict); treating N as any base costs 1.
+  auto d = make_three_leaf_star("A", "C", "N", "C");
+  fitch_assign_compact_genomes(d);
+  recompute_edge_mutations(d);
+
+  assert(edge_mutation_count(d) == 1);
+
+  parsimony_score_ops ops;
+  subtree_weight<parsimony_score_ops> sw(d, 1u);
+  auto score = sw.compute_weight_below(get_root_idx(d), ops);
+  assert(score == 1);
+
+  std::println("  score={}", score);
+  std::println("  PASS");
+}
+
+static void test_vcf_alt_no_call_populates_mask() {
+  std::println("test_vcf_alt_no_call_populates_mask");
+
+  auto path = std::filesystem::temp_directory_path() / "larch2_iupac_alt_n.vcf";
+  {
+    std::ofstream out{path};
+    out << "##fileformat=VCFv4.2\n";
+    out << "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\ts1\n";
+    out << "ref\t1\t.\tA\tN\t.\t.\t.\tGT\t1\n";
+  }
+
+  auto vcf = read_vcf(path.string(), "A");
+  auto it = vcf.sample_genomes.find("s1");
+  assert(it != vcf.sample_genomes.end());
+  assert(it->second.is_ambiguous(1));
+  assert(it->second.begin() == it->second.end());
+
+  auto d = make_three_leaf_star("A", "A", "A", "A");
+  // Rename the first leaf to match the VCF sample and apply.
+  bool renamed = false;
+  for (auto nv : d.get_all_nodes()) {
+    std::visit(
+        [&](auto node) {
+          if constexpr (requires { node.sample_id(); }) {
+            if (!renamed) {
+              node.sample_id() = "s1";
+              renamed = true;
+            }
+          }
+        },
+        nv);
+  }
+  apply_vcf_to_dag(d, vcf);
+  assert(leaf_cg(d, "s1").is_ambiguous(1));
+  assert(edge_mutation_count(d) == 0);
+
+  std::filesystem::remove(path);
+  std::println("  PASS");
+}
+
+static void test_parsimony_proto_loads_mask() {
+  std::println("test_parsimony_proto_loads_mask");
+
+  pars_data data;
+  data.newick = "(s1);";
+  data.node_mutations.resize(2);
+  data.node_mutations[1].ambiguous_sites = {1};
+
+  auto path = std::filesystem::temp_directory_path() / "larch2_iupac_parsimony.pb";
+  pb::encode_file(path.string(), data);
+  auto loaded = load_parsimony_tree(path.string(), "A");
+
+  assert(leaf_cg(loaded, "s1").is_ambiguous(1));
+  std::filesystem::remove(path);
+  std::println("  PASS");
+}
+
+static void test_proto_dag_roundtrip_preserves_mask() {
+  std::println("test_proto_dag_roundtrip_preserves_mask");
+
+  auto d = make_three_leaf_star("A", "N", "A", "A");
+  fitch_assign_compact_genomes(d);
+  recompute_edge_mutations(d);
+
+  auto path = std::filesystem::temp_directory_path() / "larch2_iupac_roundtrip.pb";
+  save_proto_dag(d, path.string());
+  auto loaded = load_proto_dag(path.string());
+
+  assert(leaf_cg(loaded, "L1").is_ambiguous(1));
+  assert(!leaf_cg(loaded, "L2").is_ambiguous(1));
+
+  std::filesystem::remove(path);
+  std::println("  PASS");
+}
+
+static void test_acgt_hash_unchanged() {
+  std::println("test_acgt_hash_unchanged");
+
+  std::map<mutation_position, nuc_base> muts{{2, nuc_base::from_char('C')}};
+  compact_genome cg{muts};
+
+  std::size_t expected = 0;
+  expected ^= std::hash<std::size_t>{}(2) + 0x9e3779b9 + (expected << 6) +
+              (expected >> 2);
+  expected ^= std::hash<std::size_t>{}(static_cast<std::size_t>('C')) +
+              0x9e3779b9 + (expected << 6) + (expected >> 2);
+
+  assert(cg.hash() == expected);
+  assert((cg == compact_genome{muts, {}}));
+  std::println("  PASS");
+}
+
+static void test_ambiguity_mask_affects_leaf_dedup() {
+  std::println("test_ambiguity_mask_affects_leaf_dedup");
+
+  compact_genome concrete = cg_from_sequence("C", "A");
+  compact_genome masked{{{1, nuc_base::from_char('C')}}, {1}};
+  assert(!(concrete == masked));
+
+  auto d = make_three_leaf_star("A", "C", "C", "A");
+  // Give L2 the same concrete mutation as L1 plus an ambiguity mask. It must
+  // not condense with L1 because their no-call semantics differ.
+  for (auto nv : d.get_all_nodes()) {
+    std::visit(
+        [&](auto node) {
+          if constexpr (requires { node.sample_id(); node.cg(); }) {
+            if (node.sample_id() == "L2") node.cg() = masked;
+          }
+        },
+        nv);
+  }
+  recompute_edge_mutations(d);
+  tree_index idx{d};
+  assert(idx.num_condensed_leaves() == 0);
+
+  std::println("  PASS");
+}
+
+int main() {
+  test_to_edge_mutations_skips_no_call();
+  test_fitch_no_call_leaf_bitmask();
+  test_vcf_alt_no_call_populates_mask();
+  test_parsimony_proto_loads_mask();
+  test_proto_dag_roundtrip_preserves_mask();
+  test_acgt_hash_unchanged();
+  test_ambiguity_mask_affects_leaf_dedup();
+  std::println("All IUPAC correctness tests passed!");
+}

--- a/test/iupac_correctness_test.cpp
+++ b/test/iupac_correctness_test.cpp
@@ -115,8 +115,7 @@ static void test_to_edge_mutations_skips_partial_iupac() {
   std::println("test_to_edge_mutations_skips_partial_iupac");
 
   compact_genome parent;
-  compact_genome child{
-      {}, std::map<mutation_position, uint8_t>{{1, iupac_state_set('Y')}}};
+  compact_genome child{{}, ambiguity_set_map{{1, iupac_state_set('Y')}}};
   auto muts = compact_genome::to_edge_mutations("A", parent, child);
 
   assert(muts.empty());
@@ -214,8 +213,7 @@ static void test_root_parent_iupac_preference() {
   std::println("test_root_parent_iupac_preference");
 
   auto d = make_two_leaf_tree("A", "Y", "Y");
-  compact_genome parent{
-      {}, std::map<mutation_position, uint8_t>{{1, iupac_state_set('K')}}};
+  compact_genome parent{{}, ambiguity_set_map{{1, iupac_state_set('K')}}};
   fitch_assign_compact_genomes(d, &parent);
 
   bool saw_t_root = false;
@@ -423,12 +421,9 @@ static void test_ambiguity_mask_affects_leaf_dedup() {
 static void test_exact_iupac_sets_affect_leaf_dedup() {
   std::println("test_exact_iupac_sets_affect_leaf_dedup");
 
-  compact_genome y{
-      {}, std::map<mutation_position, uint8_t>{{1, iupac_state_set('Y')}}};
-  compact_genome n{
-      {}, std::map<mutation_position, uint8_t>{{1, iupac_state_set('N')}}};
-  compact_genome r{
-      {}, std::map<mutation_position, uint8_t>{{1, iupac_state_set('R')}}};
+  compact_genome y{{}, ambiguity_set_map{{1, iupac_state_set('Y')}}};
+  compact_genome n{{}, ambiguity_set_map{{1, iupac_state_set('N')}}};
+  compact_genome r{{}, ambiguity_set_map{{1, iupac_state_set('R')}}};
   assert(!(y == n));
   assert(!(y == r));
 

--- a/test/iupac_correctness_test.cpp
+++ b/test/iupac_correctness_test.cpp
@@ -16,6 +16,7 @@
 #include <print>
 #include <set>
 #include <string>
+#include <type_traits>
 #include <unordered_set>
 
 using namespace larch;
@@ -78,6 +79,27 @@ static phylo_dag make_three_leaf_star(std::string_view ref,
   return d;
 }
 
+static phylo_dag make_two_leaf_tree(std::string_view ref, std::string_view a,
+                                    std::string_view b) {
+  phylo_dag d;
+  auto ua = d.append_node<node_kind::ua>();
+  ua.reference_sequence() = std::string{ref};
+  d.set_root(ua);
+
+  auto root = d.append_node<node_kind::inner>();
+  root.cg() = compact_genome{};
+  add_edge(d, ua.index(), root.index(), 0);
+
+  std::array<std::string_view, 2> seqs = {a, b};
+  for (std::size_t i = 0; i < seqs.size(); ++i) {
+    auto leaf = d.append_node<node_kind::leaf>();
+    leaf.sample_id() = "L" + std::to_string(i + 1);
+    leaf.cg() = cg_from_sequence(seqs[i], ref);
+    add_edge(d, root.index(), leaf.index(), i);
+  }
+  return d;
+}
+
 static void test_to_edge_mutations_skips_no_call() {
   std::println("test_to_edge_mutations_skips_no_call");
 
@@ -86,6 +108,29 @@ static void test_to_edge_mutations_skips_no_call() {
   auto muts = compact_genome::to_edge_mutations("C", parent, child);
 
   assert(muts.empty());
+  std::println("  PASS");
+}
+
+static void test_to_edge_mutations_skips_partial_iupac() {
+  std::println("test_to_edge_mutations_skips_partial_iupac");
+
+  compact_genome parent;
+  compact_genome child{
+      {}, std::map<mutation_position, uint8_t>{{1, iupac_state_set('Y')}}};
+  auto muts = compact_genome::to_edge_mutations("A", parent, child);
+
+  assert(muts.empty());
+  std::println("  PASS");
+}
+
+static void test_fasta_partial_iupac_state_set() {
+  std::println("test_fasta_partial_iupac_state_set");
+
+  auto cg = compact_genome_from_sequence("Y", "A");
+  assert(cg.is_ambiguous(1));
+  assert(cg.get_state_set(1, "A") == iupac_state_set('Y'));
+  assert(cg.to_string() == "<1Y,>");
+
   std::println("  PASS");
 }
 
@@ -106,6 +151,88 @@ static void test_fitch_no_call_leaf_bitmask() {
   assert(score == 1);
 
   std::println("  score={}", score);
+  std::println("  PASS");
+}
+
+static void test_fitch_partial_iupac_compatibility() {
+  std::println("test_fitch_partial_iupac_compatibility");
+
+  auto d = make_three_leaf_star("A", "C", "Y", "C");
+  fitch_assign_compact_genomes(d);
+  recompute_edge_mutations(d);
+
+  parsimony_score_ops ops;
+  subtree_weight<parsimony_score_ops> sw(d, 1u);
+  auto score = sw.compute_weight_below(get_root_idx(d), ops);
+  assert(score == 1);
+
+  std::println("  score={}", score);
+  std::println("  PASS");
+}
+
+static void test_partial_iupac_differs_from_no_call() {
+  std::println("test_partial_iupac_differs_from_no_call");
+
+  auto exact = make_two_leaf_tree("A", "G", "Y");
+  fitch_assign_compact_genomes(exact);
+  recompute_edge_mutations(exact);
+
+  auto no_call = make_two_leaf_tree("A", "G", "N");
+  fitch_assign_compact_genomes(no_call);
+  recompute_edge_mutations(no_call);
+
+  assert(edge_mutation_count(exact) == 2);
+  assert(edge_mutation_count(no_call) == 1);
+
+  std::println("  exact={}, no_call={}", edge_mutation_count(exact),
+               edge_mutation_count(no_call));
+  std::println("  PASS");
+}
+
+static void test_polytomy_iupac_fitch_counts() {
+  std::println("test_polytomy_iupac_fitch_counts");
+
+  // Four ambiguous children: AC, AG, CT, GT.  No base is compatible with more
+  // than two children, so the optimal local cost is 4 - 2 = 2.  The old
+  // binary-only shortcut incorrectly charged only one change whenever the
+  // child-set intersection was empty.
+  std::array<uint32_t, 4> balanced_counts = {2, 2, 2, 2};
+  assert(fitch_cost_from_counts(balanced_counts, 4) == 2);
+  assert(fitch_set_from_counts(balanced_counts, 4) == iupac_state_set('N'));
+
+  // AC, AG, AT, CG: A is supported by three children and is the unique optimal
+  // parent state.  Returning the full union here can make a top-down pass pick
+  // a non-optimal reference-compatible state.
+  std::array<uint32_t, 4> biased_counts = {3, 2, 2, 1};
+  assert(fitch_cost_from_counts(biased_counts, 4) == 1);
+  assert(fitch_set_from_counts(biased_counts, 4) == iupac_state_set('A'));
+
+  std::println("  PASS");
+}
+
+static void test_root_parent_iupac_preference() {
+  std::println("test_root_parent_iupac_preference");
+
+  auto d = make_two_leaf_tree("A", "Y", "Y");
+  compact_genome parent{
+      {}, std::map<mutation_position, uint8_t>{{1, iupac_state_set('K')}}};
+  fitch_assign_compact_genomes(d, &parent);
+
+  bool saw_t_root = false;
+  for (auto nv : d.get_all_nodes()) {
+    std::visit(
+        [&](auto node) {
+          if constexpr (std::is_same_v<
+                            std::remove_cvref_t<decltype(node)>,
+                            node_view<phylo_dag, node_kind::inner>>) {
+            saw_t_root =
+                node.cg().get_base(1, "A") == nuc_base::from_char('T');
+          }
+        },
+        nv);
+  }
+  assert(saw_t_root);
+
   std::println("  PASS");
 }
 
@@ -149,6 +276,28 @@ static void test_vcf_alt_no_call_populates_mask() {
   std::println("  PASS");
 }
 
+static void test_vcf_alt_partial_iupac_populates_state_set() {
+  std::println("test_vcf_alt_partial_iupac_populates_state_set");
+
+  auto path = std::filesystem::temp_directory_path() / "larch2_iupac_alt_y.vcf";
+  {
+    std::ofstream out{path};
+    out << "##fileformat=VCFv4.2\n";
+    out << "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\ts1\n";
+    out << "ref\t1\t.\tA\tY\t.\t.\t.\tGT\t1\n";
+  }
+
+  auto vcf = read_vcf(path.string(), "A");
+  auto it = vcf.sample_genomes.find("s1");
+  assert(it != vcf.sample_genomes.end());
+  assert(it->second.is_ambiguous(1));
+  assert(it->second.get_state_set(1, "A") == iupac_state_set('Y'));
+  assert(it->second.begin() == it->second.end());
+
+  std::filesystem::remove(path);
+  std::println("  PASS");
+}
+
 static void test_parsimony_proto_loads_mask() {
   std::println("test_parsimony_proto_loads_mask");
 
@@ -162,6 +311,28 @@ static void test_parsimony_proto_loads_mask() {
   auto loaded = load_parsimony_tree(path.string(), "A");
 
   assert(leaf_cg(loaded, "s1").is_ambiguous(1));
+  assert(leaf_cg(loaded, "s1").get_state_set(1, "A") == 0b1111);
+  std::filesystem::remove(path);
+  std::println("  PASS");
+}
+
+static void test_parsimony_proto_loads_exact_iupac_site() {
+  std::println("test_parsimony_proto_loads_exact_iupac_site");
+
+  pars_data data;
+  data.newick = "(s1);";
+  data.node_mutations.resize(2);
+  data.node_mutations[1].ambiguous_sites = {1};
+  data.node_mutations[1].iupac_sites = {{1, iupac_state_set('Y')}};
+
+  auto path = std::filesystem::temp_directory_path() /
+              "larch2_iupac_parsimony_exact.pb";
+  pb::encode_file(path.string(), data);
+  auto loaded = load_parsimony_tree(path.string(), "A");
+
+  assert(leaf_cg(loaded, "s1").is_ambiguous(1));
+  assert(leaf_cg(loaded, "s1").get_state_set(1, "A") ==
+         iupac_state_set('Y'));
   std::filesystem::remove(path);
   std::println("  PASS");
 }
@@ -178,6 +349,28 @@ static void test_proto_dag_roundtrip_preserves_mask() {
   auto loaded = load_proto_dag(path.string());
 
   assert(leaf_cg(loaded, "L1").is_ambiguous(1));
+  assert(leaf_cg(loaded, "L1").get_state_set(1, "A") == 0b1111);
+  assert(!leaf_cg(loaded, "L2").is_ambiguous(1));
+
+  std::filesystem::remove(path);
+  std::println("  PASS");
+}
+
+static void test_proto_dag_roundtrip_preserves_exact_iupac_site() {
+  std::println("test_proto_dag_roundtrip_preserves_exact_iupac_site");
+
+  auto d = make_three_leaf_star("A", "Y", "A", "A");
+  fitch_assign_compact_genomes(d);
+  recompute_edge_mutations(d);
+
+  auto path = std::filesystem::temp_directory_path() /
+              "larch2_iupac_exact_roundtrip.pb";
+  save_proto_dag(d, path.string());
+  auto loaded = load_proto_dag(path.string());
+
+  assert(leaf_cg(loaded, "L1").is_ambiguous(1));
+  assert(leaf_cg(loaded, "L1").get_state_set(1, "A") ==
+         iupac_state_set('Y'));
   assert(!leaf_cg(loaded, "L2").is_ambiguous(1));
 
   std::filesystem::remove(path);
@@ -227,13 +420,38 @@ static void test_ambiguity_mask_affects_leaf_dedup() {
   std::println("  PASS");
 }
 
+static void test_exact_iupac_sets_affect_leaf_dedup() {
+  std::println("test_exact_iupac_sets_affect_leaf_dedup");
+
+  compact_genome y{
+      {}, std::map<mutation_position, uint8_t>{{1, iupac_state_set('Y')}}};
+  compact_genome n{
+      {}, std::map<mutation_position, uint8_t>{{1, iupac_state_set('N')}}};
+  compact_genome r{
+      {}, std::map<mutation_position, uint8_t>{{1, iupac_state_set('R')}}};
+  assert(!(y == n));
+  assert(!(y == r));
+
+  std::println("  PASS");
+}
+
 int main() {
   test_to_edge_mutations_skips_no_call();
+  test_to_edge_mutations_skips_partial_iupac();
+  test_fasta_partial_iupac_state_set();
   test_fitch_no_call_leaf_bitmask();
+  test_fitch_partial_iupac_compatibility();
+  test_partial_iupac_differs_from_no_call();
+  test_polytomy_iupac_fitch_counts();
+  test_root_parent_iupac_preference();
   test_vcf_alt_no_call_populates_mask();
+  test_vcf_alt_partial_iupac_populates_state_set();
   test_parsimony_proto_loads_mask();
+  test_parsimony_proto_loads_exact_iupac_site();
   test_proto_dag_roundtrip_preserves_mask();
+  test_proto_dag_roundtrip_preserves_exact_iupac_site();
   test_acgt_hash_unchanged();
   test_ambiguity_mask_affects_leaf_dedup();
+  test_exact_iupac_sets_affect_leaf_dedup();
   std::println("All IUPAC correctness tests passed!");
 }

--- a/test/iupac_correctness_test.cpp
+++ b/test/iupac_correctness_test.cpp
@@ -388,7 +388,7 @@ static void test_acgt_hash_unchanged() {
               0x9e3779b9 + (expected << 6) + (expected >> 2);
 
   assert(cg.hash() == expected);
-  assert((cg == compact_genome{muts, {}}));
+  assert((cg == compact_genome{muts, ambiguity_set_map{}}));
   std::println("  PASS");
 }
 

--- a/test/iupac_correctness_test.cpp
+++ b/test/iupac_correctness_test.cpp
@@ -104,7 +104,7 @@ static void test_to_edge_mutations_skips_no_call() {
   std::println("test_to_edge_mutations_skips_no_call");
 
   compact_genome parent;
-  compact_genome child{{}, {1}};
+  compact_genome child{{}, ambiguity_set_map{{1, 0b1111}}};
   auto muts = compact_genome::to_edge_mutations("C", parent, child);
 
   assert(muts.empty());
@@ -321,7 +321,12 @@ static void test_parsimony_proto_loads_exact_iupac_site() {
   data.newick = "(s1);";
   data.node_mutations.resize(2);
   data.node_mutations[1].ambiguous_sites = {1};
-  data.node_mutations[1].iupac_sites = {{1, iupac_state_set('Y')}};
+  data.node_mutations[1].iupac_sites = {
+      pars_iupac_site{
+          .position = 1,
+          .state_set = iupac_state_set('Y'),
+      },
+  };
 
   auto path = std::filesystem::temp_directory_path() /
               "larch2_iupac_parsimony_exact.pb";
@@ -388,7 +393,7 @@ static void test_acgt_hash_unchanged() {
               0x9e3779b9 + (expected << 6) + (expected >> 2);
 
   assert(cg.hash() == expected);
-  assert((cg == compact_genome{muts, {}}));
+  assert((cg == compact_genome{muts, ambiguity_set_map{}}));
   std::println("  PASS");
 }
 
@@ -396,7 +401,8 @@ static void test_ambiguity_mask_affects_leaf_dedup() {
   std::println("test_ambiguity_mask_affects_leaf_dedup");
 
   compact_genome concrete = cg_from_sequence("C", "A");
-  compact_genome masked{{{1, nuc_base::from_char('C')}}, {1}};
+  compact_genome masked{{{1, nuc_base::from_char('C')}},
+                        ambiguity_set_map{{1, 0b1111}}};
   assert(!(concrete == masked));
 
   auto d = make_three_leaf_star("A", "C", "C", "A");

--- a/tools/dagutil.cpp
+++ b/tools/dagutil.cpp
@@ -58,6 +58,7 @@ static phylo_dag build_from_fasta_newick(std::string_view fasta_path,
   auto entries = read_fasta(fasta_path);
   std::unordered_map<std::string, std::string> fasta_map;
   for (auto& e : entries) fasta_map[e.name] = std::move(e.sequence);
+  ambiguity_counts ambiguity;
 
   auto nw_bytes = read_file(newick_path);
   std::string newick_str{nw_bytes.data(), nw_bytes.size()};
@@ -137,19 +138,13 @@ static phylo_dag build_from_fasta_newick(std::string_view fasta_path,
             auto it = fasta_map.find(node.sample_id());
             if (it == fasta_map.end()) return;
             auto& seq = it->second;
-            std::map<mutation_position, nuc_base> muts;
-            for (std::size_t i = 0; i < seq.size() && i < reference.size();
-                 ++i) {
-              auto ref_base = nuc_base::from_char(reference[i]);
-              auto seq_base = nuc_base::from_char(seq[i]);
-              if (!(ref_base == seq_base)) muts[i + 1] = seq_base;
-            }
-            node.cg() = compact_genome{std::move(muts)};
+            node.cg() = compact_genome_from_sequence(seq, reference, &ambiguity);
           }
         },
         nv);
   }
 
+  warn_if_ambiguities(ambiguity, "input alignment");
   fitch_assign_compact_genomes(d);
   recompute_edge_mutations(d);
   return d;

--- a/tools/dagutil.cpp
+++ b/tools/dagutil.cpp
@@ -144,7 +144,7 @@ static phylo_dag build_from_fasta_newick(std::string_view fasta_path,
         nv);
   }
 
-  warn_if_ambiguities(ambiguity, "input alignment");
+  warn_if_ambiguities(ambiguity, "input alignment", std::cerr);
   fitch_assign_compact_genomes(d);
   recompute_edge_mutations(d);
   return d;
@@ -348,6 +348,7 @@ int main(int argc, char** argv) try {
     parallel_for_each(pool, indices, [&](std::size_t idx) {
       auto const& ref = get_reference_sequence(dags[idx]);
       auto vcf = read_vcf(a.vcf, ref);
+      warn_if_ambiguities(vcf.ambiguity, "VCF genotypes", std::cerr);
       apply_vcf_to_dag(dags[idx], vcf);
     });
   }

--- a/tools/larch2.cpp
+++ b/tools/larch2.cpp
@@ -211,6 +211,7 @@ static phylo_dag build_from_fasta_newick(std::string_view fasta_path,
   auto entries = read_fasta(fasta_path);
   std::unordered_map<std::string, std::string> fasta_map;
   for (auto& e : entries) fasta_map[e.name] = std::move(e.sequence);
+  ambiguity_counts ambiguity;
 
   // Read newick string
   auto nw_bytes = read_file(newick_path);
@@ -310,19 +311,13 @@ static phylo_dag build_from_fasta_newick(std::string_view fasta_path,
             auto it = fasta_map.find(node.sample_id());
             if (it == fasta_map.end()) return;
             auto& seq = it->second;
-            std::map<mutation_position, nuc_base> muts;
-            for (std::size_t i = 0; i < seq.size() && i < reference.size();
-                 ++i) {
-              auto ref_base = nuc_base::from_char(reference[i]);
-              auto seq_base = nuc_base::from_char(seq[i]);
-              if (!(ref_base == seq_base)) muts[i + 1] = seq_base;
-            }
-            node.cg() = compact_genome{std::move(muts)};
+            node.cg() = compact_genome_from_sequence(seq, reference, &ambiguity);
           }
         },
         nv);
   }
 
+  warn_if_ambiguities(ambiguity, "input alignment");
   fitch_assign_compact_genomes(d);
   recompute_edge_mutations(d);
   return d;

--- a/tools/larch2.cpp
+++ b/tools/larch2.cpp
@@ -317,7 +317,7 @@ static phylo_dag build_from_fasta_newick(std::string_view fasta_path,
         nv);
   }
 
-  warn_if_ambiguities(ambiguity, "input alignment");
+  warn_if_ambiguities(ambiguity, "input alignment", std::cerr);
   fitch_assign_compact_genomes(d);
   recompute_edge_mutations(d);
   return d;
@@ -2123,6 +2123,7 @@ int main(int argc, char** argv) {
     std::cerr << "Applying VCF from " << a.vcf << "...\n";
     auto const& ref = get_reference_sequence(dag);
     auto vcf = read_vcf(a.vcf, ref);
+    warn_if_ambiguities(vcf.ambiguity, "VCF genotypes", std::cerr);
     apply_vcf_to_dag(dag, vcf);
     if (a.validate) validate_dag(dag, "after VCF", thread_pool::get_default());
   }


### PR DESCRIPTION
   ## Summary                                                                                                    
                                                                                                                 
   This PR adds exact IUPAC ambiguity-state support throughout compact genomes, FASTA/VCF parsing, Fitch         
 scoring, and DAG/parsimony protobuf IO.                                                                         
                                                                                                                 
   Previously, IUPAC ambiguity codes were effectively treated as all-base no-calls. This made partial ambiguity  
 codes such as `Y` (`C|T`) or `R` (`A|G`) too permissive during parsimony scoring. This PR stores and scores the 
 exact state set represented by each IUPAC code.                                                                 
                                                                                                                 
   ## What changed                                                                                               
                                                                                                                 
   ### Compact genomes                                                                                           
                                                                                                                 
   - `compact_genome` now stores exact non-singleton IUPAC state sets in:                                        
                                                                                                                 
     ```cpp                                                                                                      
     ambiguity_set_map ambiguity_sets_;                                                                          
 ```                                                                                                             
                                                                                                                 
 - State-set bit encoding:                                                                                       
   ```text                                                                                                       
     A = 1                                                                                                       
     C = 2                                                                                                       
     G = 4                                                                                                       
     T = 8                                                                                                       
   ```                                                                                                           
 - Added helpers/types:                                                                                          
   ```cpp                                                                                                        
     using iupac_state_set_t = uint8_t;                                                                          
     using ambiguity_set_map = std::map<mutation_position, iupac_state_set_t>;                                   
                                                                                                                 
     iupac_state_set(char)                                                                                       
     iupac_char_from_state_set(iupac_state_set_t)                                                                
     compact_genome::ambiguity_sets()                                                                            
     compact_genome::set_ambiguity_sets(...)                                                                     
     compact_genome::get_state_set(pos, ref)                                                                     
   ```                                                                                                           
 - Existing ambiguity_mask() / set_ambiguity_mask() APIs remain as compatibility wrappers over full no-call      
 sites (0b1111).                                                                                                 
 - Hash/equality now include exact (position, state_set) ambiguity information, while preserving the historical  
 hash for ACGT-only compact genomes.                                                                             
 - compact_genome::to_string() prints human-readable IUPAC codes, e.g.:                                          
   ```text                                                                                                       
     <1Y,>                                                                                                       
   ```                                                                                                           
                                                                                                                 
 ### FASTA / VCF parsing                                                                                         
                                                                                                                 
 - FASTA parsing now records exact IUPAC state sets:                                                             
     - Y stores C|T                                                                                              
     - R stores A|G                                                                                              
     - etc.                                                                                                      
     - N, -, and ? remain full no-calls.                                                                         
 - VCF parsing now records exact IUPAC sets for ambiguous REF/ALT alleles.                                       
 - Warning text now refers to “IUPAC ambiguity/no-call codes” and explains that partial IUPAC codes are treated  
 as compatible state sets during Fitch parsimony.                                                                
                                                                                                                 
 ### Fitch/parsimony scoring                                                                                     
                                                                                                                 
 - Fitch initialization for leaves now uses exact state sets via:                                                
   ```cpp                                                                                                        
     compact_genome::get_state_set(pos, ref)                                                                     
   ```                                                                                                           
 - Variable-site collection includes ambiguity-set sites.                                                        
 - Generalized the Fitch helpers for multifurcations and ambiguous child sets:                                   
     - local cost is num_children - max_base_support                                                             
     - parent Fitch set is the set of bases attaining that maximum                                               
 - This reduces to the usual intersection/union rule for binary nodes, while correctly handling polytomies with  
 ambiguous child states.                                                                                         
 - Fragment-root assignment now consults an ambiguous parent compact genome via root_parent_cg->get_state_set()  
 rather than forcing a concrete parent base.                                                                     
                                                                                                                 
 ### Edge mutations                                                                                              
                                                                                                                 
 Edge mutation emission remains conservative:                                                                    
                                                                                                                 
 - if either endpoint has an ambiguity set at a site, no edge mutation is emitted for that site                  
                                                                                                                 
 This preserves the previous no-call behavior for ambiguous sites.                                               
                                                                                                                 
 ### Protobuf IO                                                                                                 
                                                                                                                 
 Added exact IUPAC ambiguity-site fields while preserving backwards compatibility:                               
                                                                                                                 
 - proto/dag.proto                                                                                               
     - added ambiguous_site { position, state_set }                                                              
     - added node_name.iupac_sites = 4                                                                           
 - proto/parsimony.proto                                                                                         
     - added ambiguous_site { position, state_set }                                                              
     - added mutation_list.iupac_sites = 3                                                                       
                                                                                                                 
 Loaders now:                                                                                                    
                                                                                                                 
 - read legacy ambiguous_sites as full no-calls (0b1111)                                                         
 - let exact iupac_sites override duplicate legacy positions                                                     
                                                                                                                 
 DAG saver now:                                                                                                  
                                                                                                                 
 - emits exact iupac_sites                                                                                       
 - also emits legacy ambiguous_sites for full no-call sites for compatibility                                    
                                                                                                                 
 Tests                                                                                                           
                                                                                                                 
 Added/updated test/iupac_correctness_test.cpp coverage for:                                                     
                                                                                                                 
 - FASTA parsing of partial IUPAC codes                                                                          
 - edge mutations skipping partial IUPAC sites                                                                   
 - exact partial-IUPAC Fitch scoring                                                                             
 - distinction between partial IUPAC and full no-call behavior                                                   
 - polytomy scoring with ambiguous child sets                                                                    
 - top-down root-parent IUPAC preference                                                                         
 - VCF ALT ambiguity parsing                                                                                     
 - parsimony proto exact iupac_sites loading                                                                     
 - DAG proto exact IUPAC roundtrip                                                                               
 - equality/hash behavior for different ambiguity sets                                                           
 - existing no-call behavior