### PR TITLE
Add configurable checkpointing to the larch2 optimization loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ endif()
 
 # --- Library ------------------------------------------------------------------
 
-add_library(larch src/protobuf.cpp src/protobuf_encode.cpp)
+add_library(larch src/protobuf.cpp src/protobuf_encode.cpp src/checkpoint.cpp)
 target_include_directories(larch PUBLIC include ${CMAKE_BINARY_DIR}/generated)
 target_link_libraries(larch PUBLIC ZLIB::ZLIB Threads::Threads)
 
@@ -141,9 +141,26 @@ foreach(test_name merge_test merge_consistency_test subtree_weight_test
                   weight_accum_test optimize_test native_optimize_test
                   spr_pipeline_test trim_clade_edges_test
                   # rotaA_diagnostic_test
-                  inplace_spr_test)
+                  inplace_spr_test checkpoint_test)
     add_executable(${test_name} test/${test_name}.cpp)
     target_link_libraries(${test_name} PRIVATE larch)
     add_test(NAME ${test_name} COMMAND ${test_name}
              WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 endforeach()
+
+# Helper used by the integration test to compare two .pb.gz files under
+# canonical ordering (sorted edges / node_names / condensed_leaves).
+add_executable(dag_canonical_equal test/dag_canonical_equal.cpp)
+target_link_libraries(dag_canonical_equal PRIVATE larch)
+
+# Integration test: the larch2 CLI checkpoint flow end-to-end, including
+# Phase 1 / Phase 2 resume, args fingerprint mismatch, and forbidden-flag
+# enforcement. Driven by a shell script so we can SIGKILL mid-run and assert
+# canonical equality on the resulting protobuf files.
+if(TARGET larch2)
+    add_test(NAME checkpoint_integration_test
+             COMMAND ${CMAKE_SOURCE_DIR}/test/checkpoint_integration.sh
+             $<TARGET_FILE:larch2>
+             $<TARGET_FILE:dag_canonical_equal>
+             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+endif()

--- a/README.md
+++ b/README.md
@@ -93,6 +93,26 @@ larch2 [options] -o <output.pb.gz>
 | `--min-subtree-clade-size <N>` | 100 | Minimum leaves in selected subtree |
 | `--max-subtree-clade-size <N>` | 1000 | Maximum leaves in selected subtree |
 
+### Checkpointing
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--checkpoint-after <N>` | off | Write a checkpoint every N completed iterations, plus one immediately before each drift-escape entry (native optimizer only) |
+| `--checkpoint-prefix <P>` | derived | Override checkpoint path prefix (default strips `.pb.gz` from `--output`) |
+| `--resume <path>` | off | Resume from a checkpoint file. Mutually exclusive with `--dag-pb`, `--tree-pb`, `--fasta`, `--newick`, `--refseq`, `--vcf` (the checkpoint is self-describing) |
+
+Checkpoint files are written atomically (`<path>.tmp` then renamed). Iteration-boundary checkpoints are named `<prefix>.ckpt-<iter>.pb.gz`; pre-drift checkpoints are named `<prefix>.ckpt-<iter>-pre-drift.pb.gz`.
+
+A resumed run that uses the same `--seed` and the same fingerprinted args (every flag in this section EXCEPT `--output`, `--trim`, `--validate`, `--log-metrics`, and the `--diverse-*` outputs) is canonical-equivalent to the corresponding uninterrupted run. Changing a fingerprinted arg on resume is rejected with an error naming the conflicting field.
+
+```sh
+# Run 6 iters, checkpointing every iter
+larch2 --dag-pb input.pb.gz -n 6 --checkpoint-after 1 --seed 42 -o out.pb.gz
+
+# Later, resume from iter 3 to completion
+larch2 --resume out.ckpt-3.pb.gz -n 6 --seed 42 -o resumed.pb.gz
+```
+
 ### Diverse tree extraction
 
 | Option | Default | Description |

--- a/include/larch/checkpoint.hpp
+++ b/include/larch/checkpoint.hpp
@@ -1,0 +1,149 @@
+#pragma once
+
+#include <larch/io_util.hpp>
+#include <larch/load_proto_dag.hpp>
+#include <larch/protobuf.hpp>
+#include <larch/protobuf_encode.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <optional>
+#include <random>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace larch {
+
+constexpr int32_t checkpoint_schema_version = 1;
+
+// --- Proto-mirror structs (see proto/checkpoint.proto) -----------------
+
+struct patience_state_msg {
+  std::optional<int64_t> limit;
+  int64_t count;
+  std::optional<int64_t> best_score;
+};
+
+struct rng_state_msg {
+  std::string mt19937_state;
+};
+
+struct radius_result_msg_pb {
+  int64_t radius;
+  int64_t moves_found;
+  int64_t moves_applied;
+  int64_t parsimony_score;
+};
+
+struct optimize_result_msg_pb {
+  int64_t iteration;
+  int64_t dag_node_count;
+  int64_t dag_edge_count;
+  int64_t trees_merged;
+  int64_t parsimony_score;
+  std::vector<radius_result_msg_pb> radii;
+};
+
+struct larch_checkpoint_msg {
+  int32_t schema_version;
+  std::string larch2_git_sha;
+  int64_t next_iteration;
+  std::string optimizer;
+  patience_state_msg patience;
+  rng_state_msg main_rng;
+  rng_state_msg drift_rng;  // empty mt19937_state == not present
+  std::vector<optimize_result_msg_pb> results;
+  dag_data dag;
+  std::string args_fingerprint;  // SHA-256 hex digest of args_payload
+  std::string args_payload;      // JSON of fingerprinted args (for diff
+                                 // reporting on mismatch)
+};
+
+}  // namespace larch
+
+// --- std::optional<int64_t> protobuf overloads ------------------------------
+// The default int64_t encoder skips zero values, but proto3 "optional uint64"
+// must distinguish "0" from "unset". We emit on has_value() and decode into
+// the optional unconditionally.
+namespace pb {
+
+inline void encode_field(std::optional<int64_t> const& f, uint32_t fnum,
+                         writer& w) {
+  if (!f.has_value()) return;
+  w.write_tag(fnum, wire_type::varint);
+  w.write_varint(static_cast<uint64_t>(*f));
+}
+
+inline void decode_field(std::optional<int64_t>& f, wire_type, reader& r) {
+  f = static_cast<int64_t>(r.read_varint());
+}
+
+}  // namespace pb
+
+namespace larch {
+
+// --- mt19937 (de)serialization (round-trips exactly per C++ standard) ------
+
+inline std::string serialize_mt19937(std::mt19937 const& rng) {
+  std::ostringstream oss;
+  oss << rng;
+  return oss.str();
+}
+
+inline std::mt19937 deserialize_mt19937(std::string const& s) {
+  std::istringstream iss{s};
+  std::mt19937 rng;
+  iss >> rng;
+  if (iss.fail())
+    throw std::runtime_error{"deserialize_mt19937: parse failed"};
+  return rng;
+}
+
+// --- Format detection -----------------------------------------------------
+// Phase 2 checkpoints always have schema_version >= 1, so the encoded file
+// starts with the bytes [0x08, schema_version_varint]. A raw dag_data file
+// (Phase 1 / legacy) starts with field 1 (edges, length-delimited) tagged
+// 0x0a, or another length-delimited field if edges is empty. The byte 0x08
+// uniquely identifies a larch_checkpoint.
+inline bool looks_like_checkpoint(std::span<const uint8_t> data) {
+  return !data.empty() && data[0] == 0x08;
+}
+
+// --- File IO --------------------------------------------------------------
+
+inline std::vector<char> read_checkpoint_bytes(std::string_view path) {
+  return read_file(path);  // handles both gzipped and plain
+}
+
+// Atomic write: encode -> "<path>.tmp" -> rename to "<path>".
+inline void write_checkpoint(larch_checkpoint_msg const& ckpt,
+                             std::string_view path) {
+  auto bytes = pb::encode(ckpt);
+  std::string tmp = std::string{path} + ".tmp";
+  {
+    std::ofstream out{tmp, std::ios::binary};
+    if (!out)
+      throw std::runtime_error{"cannot open " + tmp + " for writing"};
+    out.write(reinterpret_cast<const char*>(bytes.data()),
+              static_cast<std::streamsize>(bytes.size()));
+    if (!out) throw std::runtime_error{"write failed: " + tmp};
+  }
+  if (std::rename(tmp.c_str(), std::string{path}.c_str()) != 0)
+    throw std::runtime_error{"rename failed: " + tmp + " -> " +
+                             std::string{path}};
+}
+
+inline larch_checkpoint_msg load_checkpoint_from_bytes(
+    std::span<const uint8_t> data) {
+  return pb::decode<larch_checkpoint_msg>(data);
+}
+
+// --- SHA-256 (for args fingerprint) ---------------------------------------
+
+std::string sha256_hex(std::string_view data);
+
+}  // namespace larch

--- a/include/larch/checkpoint.hpp
+++ b/include/larch/checkpoint.hpp
@@ -108,7 +108,13 @@ inline std::mt19937 deserialize_mt19937(std::string const& s) {
 // starts with the bytes [0x08, schema_version_varint]. A raw dag_data file
 // (Phase 1 / legacy) starts with field 1 (edges, length-delimited) tagged
 // 0x0a, or another length-delimited field if edges is empty. The byte 0x08
-// uniquely identifies a larch_checkpoint.
+// uniquely identifies a larch_checkpoint. Detection assumes
+// checkpoint_schema_version > 0 — proto3 omits zero-default fields on the
+// wire, which would invert the magic byte test.
+static_assert(checkpoint_schema_version > 0,
+              "checkpoint_schema_version must be > 0 for looks_like_checkpoint "
+              "to reliably detect Phase 2 files");
+
 inline bool looks_like_checkpoint(std::span<const uint8_t> data) {
   return !data.empty() && data[0] == 0x08;
 }

--- a/include/larch/checkpoint.hpp
+++ b/include/larch/checkpoint.hpp
@@ -32,20 +32,20 @@ struct rng_state_msg {
   std::string mt19937_state;
 };
 
-struct radius_result_msg_pb {
+struct radius_result_msg {
   int64_t radius;
   int64_t moves_found;
   int64_t moves_applied;
   int64_t parsimony_score;
 };
 
-struct optimize_result_msg_pb {
+struct optimize_result_msg {
   int64_t iteration;
   int64_t dag_node_count;
   int64_t dag_edge_count;
   int64_t trees_merged;
   int64_t parsimony_score;
-  std::vector<radius_result_msg_pb> radii;
+  std::vector<radius_result_msg> radii;
 };
 
 struct larch_checkpoint_msg {
@@ -56,7 +56,7 @@ struct larch_checkpoint_msg {
   patience_state_msg patience;
   rng_state_msg main_rng;
   rng_state_msg drift_rng;  // empty mt19937_state == not present
-  std::vector<optimize_result_msg_pb> results;
+  std::vector<optimize_result_msg> results;
   dag_data dag;
   std::string args_fingerprint;  // SHA-256 hex digest of args_payload
   std::string args_payload;      // JSON of fingerprinted args (for diff

--- a/include/larch/load_proto_dag.hpp
+++ b/include/larch/load_proto_dag.hpp
@@ -71,35 +71,11 @@ inline constexpr auto field_numbers<larch::dag_data_meta> =
 
 namespace larch {
 
-inline phylo_dag load_proto_dag(std::string_view path) {
-  // Get raw data via mmap (plain .pb) or read_file (.pb.gz)
-  std::optional<mmap_file> mf;
-  std::vector<char> file_bytes;
-  std::span<const uint8_t> data;
-  if (!is_gzipped(path)) {
-    mf.emplace(path);
-    data = mf->span();
-  } else {
-    file_bytes = read_file(path);
-    data = {reinterpret_cast<const uint8_t*>(file_bytes.data()),
-            file_bytes.size()};
-  }
-
-  // Parallel decode edges (field 1 = repeated dag_edge)
-  auto edge_spans = pb::collect_field_spans(data, 1);
-  std::vector<dag_edge> edges(edge_spans.size());
-  {
-    std::vector<std::size_t> indices(edge_spans.size());
-    std::iota(indices.begin(), indices.end(), std::size_t{0});
-    parallel_for_each(indices, [&](std::size_t i) {
-      edges[i] = pb::decode<dag_edge>(edge_spans[i]);
-    });
-  }
-
-  // Decode remaining fields sequentially (node_names, reference_id,
-  // reference_seq)
-  auto meta = pb::decode<dag_data_meta>(data);
-
+// Build a phylo_dag from an already-decoded edges vector and metadata.
+// Shared by both load_proto_dag (parallel decode of file bytes) and the
+// checkpoint resume path (where edges live nested inside larch_checkpoint).
+inline phylo_dag build_phylo_dag_from_proto(std::vector<dag_edge> edges,
+                                            dag_data_meta meta) {
   phylo_dag d;
 
   // Create UA node with reference sequence
@@ -140,11 +116,20 @@ inline phylo_dag load_proto_dag(std::string_view path) {
     }
   }
 
-  // Create DAG nodes. Proto root maps to our UA node.
+  // Create DAG nodes. Proto root maps to our UA node. Walk proto IDs in
+  // sorted order so the resulting phylo_dag node ordering is deterministic
+  // — otherwise the unordered_map iteration order would make load+save round
+  // trips lose the original node-index layout, breaking determinism for any
+  // operation that traverses by index (e.g. sampling).
   std::pmr::unordered_map<std::size_t, std::size_t> proto_to_dag(mr);
   proto_to_dag[proto_root_id] = ua.index();
 
-  for (auto [proto_id, _] : all_node_ids) {
+  std::pmr::vector<std::size_t> sorted_proto_ids(mr);
+  sorted_proto_ids.reserve(all_node_ids.size());
+  for (auto [proto_id, _] : all_node_ids) sorted_proto_ids.push_back(proto_id);
+  std::sort(sorted_proto_ids.begin(), sorted_proto_ids.end());
+
+  for (auto proto_id : sorted_proto_ids) {
     if (proto_id == proto_root_id) continue;  // Already mapped to UA
 
     bool has_sample = node_sample_ids.contains(proto_id);
@@ -160,20 +145,13 @@ inline phylo_dag load_proto_dag(std::string_view path) {
     }
   }
 
-  // Sort edges by parent_node so that each parent's children list grows
-  // contiguously at the high-water mark of the neighbors chain, avoiding
-  // O(k^2) reallocation per high-degree node.
+  // Sort edges by edge_id (sequential append-order from save_proto_dag) so
+  // that load+save preserves the original phylo_dag internal edge indexing
+  // and per-node neighbor-list ordering. Internal ordering is observable
+  // (sampling traversals follow children-list order), so the previous
+  // parent-sort optimization broke determinism for resume-from-checkpoint.
   std::sort(edges.begin(), edges.end(),
-            [](auto& a, auto& b) { return a.parent_node < b.parent_node; });
-
-  // Phase 1: Create edges, set mutations, and link parents (builds children
-  // lists contiguously since edges are sorted by parent).
-  struct pending_child {
-    std::size_t edge_idx;
-    std::size_t child_dag_idx;
-  };
-  std::pmr::vector<pending_child> pending(mr);
-  pending.reserve(edges.size());
+            [](auto& a, auto& b) { return a.edge_id < b.edge_id; });
 
   for (auto& re : edges) {
     auto parent_idx = proto_to_dag[static_cast<std::size_t>(re.parent_node)];
@@ -191,22 +169,7 @@ inline phylo_dag load_proto_dag(std::string_view path) {
     edge.clade_index() = static_cast<std::size_t>(re.parent_clade);
 
     std::visit([&](auto p) { edge.set_parent(p); }, d.get_node(parent_idx));
-    pending.push_back({edge.index(), child_idx});
-  }
-
-  // Phase 2: Link children, sorted by child node so that each child's
-  // parents list also grows contiguously.
-  std::sort(pending.begin(), pending.end(),
-            [](auto& a, auto& b) { return a.child_dag_idx < b.child_dag_idx; });
-
-  for (auto& pc : pending) {
-    auto ev = d.get_edge(pc.edge_idx);
-    std::visit(
-        [&](auto edge) {
-          std::visit([&](auto c) { edge.set_child(c); },
-                     d.get_node(pc.child_dag_idx));
-        },
-        ev);
+    std::visit([&](auto c) { edge.set_child(c); }, d.get_node(child_idx));
   }
 
   recompute_compact_genomes(d);
@@ -241,6 +204,38 @@ inline phylo_dag load_proto_dag(std::string_view path) {
 
   build_clade_offsets(d);
   return d;
+}
+
+inline phylo_dag load_proto_dag(std::string_view path) {
+  // Get raw data via mmap (plain .pb) or read_file (.pb.gz)
+  std::optional<mmap_file> mf;
+  std::vector<char> file_bytes;
+  std::span<const uint8_t> data;
+  if (!is_gzipped(path)) {
+    mf.emplace(path);
+    data = mf->span();
+  } else {
+    file_bytes = read_file(path);
+    data = {reinterpret_cast<const uint8_t*>(file_bytes.data()),
+            file_bytes.size()};
+  }
+
+  // Parallel decode edges (field 1 = repeated dag_edge)
+  auto edge_spans = pb::collect_field_spans(data, 1);
+  std::vector<dag_edge> edges(edge_spans.size());
+  {
+    std::vector<std::size_t> indices(edge_spans.size());
+    std::iota(indices.begin(), indices.end(), std::size_t{0});
+    parallel_for_each(indices, [&](std::size_t i) {
+      edges[i] = pb::decode<dag_edge>(edge_spans[i]);
+    });
+  }
+
+  // Decode remaining fields sequentially (node_names, reference_id,
+  // reference_seq)
+  auto meta = pb::decode<dag_data_meta>(data);
+
+  return build_phylo_dag_from_proto(std::move(edges), std::move(meta));
 }
 
 }  // namespace larch

--- a/include/larch/save_proto_dag.hpp
+++ b/include/larch/save_proto_dag.hpp
@@ -8,8 +8,13 @@
 
 namespace larch {
 
-inline void save_proto_dag(phylo_dag& dag, std::string_view path,
-                           std::vector<float> const& edge_scores) {
+// Translate an in-memory phylo_dag into the proto-mirror dag_data struct.
+// Both save_proto_dag and the larch_checkpoint writer in tools/larch2.cpp
+// need this — keeping it in one place ensures any future schema change
+// (new mutation field, changed node id allocation, etc.) only has to be
+// updated once.
+inline dag_data encode_dag_to_proto(
+    phylo_dag& dag, std::vector<float> const& edge_scores = {}) {
   assert(edge_scores.empty() || edge_scores.size() >= dag.edge_high_mark());
   dag_data data;
   data.reference_seq = get_reference_sequence(dag);
@@ -74,7 +79,12 @@ inline void save_proto_dag(phylo_dag& dag, std::string_view path,
         nv);
   }
 
-  pb::encode_file(path, data);
+  return data;
+}
+
+inline void save_proto_dag(phylo_dag& dag, std::string_view path,
+                           std::vector<float> const& edge_scores) {
+  pb::encode_file(path, encode_dag_to_proto(dag, edge_scores));
 }
 
 inline void save_proto_dag(phylo_dag& dag, std::string_view path) {

--- a/proto/checkpoint.proto
+++ b/proto/checkpoint.proto
@@ -1,0 +1,63 @@
+syntax = "proto3";
+
+package ProtoDAG;
+
+import "dag.proto";
+
+/// Patience-checker state. limit mirrors args.patience (unset if --patience
+/// was not passed). count is the current consecutive-no-improvement run.
+/// best_score is the best-so-far parsimony score; absent until at least one
+/// iteration has completed.
+message patience_state {
+  optional uint64 limit = 1;
+  uint64 count = 2;
+  optional uint64 best_score = 3;
+}
+
+/// std::mt19937 state, serialized via std::ostringstream + operator<<.
+/// The C++ standard guarantees byte-exact round-trip across operator<</>>.
+message rng_state {
+  bytes mt19937_state = 1;
+}
+
+/// Mirror of the C++ radius_result struct; one entry per radius pass within
+/// an iteration.
+message radius_result_msg {
+  uint64 radius = 1;
+  uint64 moves_found = 2;
+  uint64 moves_applied = 3;
+  uint64 parsimony_score = 4;
+}
+
+/// Mirror of the C++ optimize_result struct; one entry per completed
+/// iteration in the optimization loop.
+message optimize_result_msg {
+  uint64 iteration = 1;
+  uint64 dag_node_count = 2;
+  uint64 dag_edge_count = 3;
+  uint64 trees_merged = 4;
+  uint64 parsimony_score = 5;
+  repeated radius_result_msg radii = 6;
+}
+
+/// Phase 2 checkpoint: the merged DAG plus enough optimization state to
+/// resume an interrupted run such that the resumed final output is
+/// canonical-byte-identical to an uninterrupted run with the same seeds.
+message larch_checkpoint {
+  uint32 schema_version = 1;
+  string larch2_git_sha = 2;
+  uint64 next_iteration = 3;
+  string optimizer = 4;
+  patience_state patience = 5;
+  rng_state main_rng = 6;
+  optional rng_state drift_rng = 7;
+  repeated optimize_result_msg results = 8;
+  ProtoDAG.data dag = 9;
+  /// SHA-256 hex digest of args_payload. Recomputed on resume and compared
+  /// to detect args changes that would invalidate determinism.
+  string args_fingerprint = 10;
+  /// JSON serialization of the fingerprinted args fields. Stored alongside
+  /// the digest so we can identify which specific field changed when the
+  /// digests mismatch.
+  string args_payload = 11;
+}

--- a/src/checkpoint.cpp
+++ b/src/checkpoint.cpp
@@ -1,0 +1,111 @@
+#include <larch/checkpoint.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+// --- SHA-256 -----------------------------------------------------------
+// Self-contained SHA-256 implementation, used only for args_fingerprint.
+// FIPS 180-4 reference. No external crypto dep — the existing build has
+// only zlib + pthreads.
+
+namespace {
+
+constexpr uint32_t sha256_k[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+
+constexpr uint32_t rotr(uint32_t x, uint32_t n) {
+  return (x >> n) | (x << (32 - n));
+}
+
+void sha256_compress(std::array<uint32_t, 8>& h, const uint8_t block[64]) {
+  uint32_t w[64];
+  for (int i = 0; i < 16; ++i) {
+    w[i] = (uint32_t(block[i * 4]) << 24) | (uint32_t(block[i * 4 + 1]) << 16) |
+           (uint32_t(block[i * 4 + 2]) << 8) | uint32_t(block[i * 4 + 3]);
+  }
+  for (int i = 16; i < 64; ++i) {
+    uint32_t s0 = rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >> 3);
+    uint32_t s1 = rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >> 10);
+    w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+  }
+  uint32_t a = h[0], b = h[1], c = h[2], d = h[3];
+  uint32_t e = h[4], f = h[5], g = h[6], hh = h[7];
+  for (int i = 0; i < 64; ++i) {
+    uint32_t S1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+    uint32_t ch = (e & f) ^ (~e & g);
+    uint32_t t1 = hh + S1 + ch + sha256_k[i] + w[i];
+    uint32_t S0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+    uint32_t mj = (a & b) ^ (a & c) ^ (b & c);
+    uint32_t t2 = S0 + mj;
+    hh = g;
+    g = f;
+    f = e;
+    e = d + t1;
+    d = c;
+    c = b;
+    b = a;
+    a = t1 + t2;
+  }
+  h[0] += a;
+  h[1] += b;
+  h[2] += c;
+  h[3] += d;
+  h[4] += e;
+  h[5] += f;
+  h[6] += g;
+  h[7] += hh;
+}
+
+}  // namespace
+
+namespace larch {
+
+std::string sha256_hex(std::string_view data) {
+  std::array<uint32_t, 8> h{0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+                            0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
+
+  uint64_t bit_len = static_cast<uint64_t>(data.size()) * 8;
+  const uint8_t* p = reinterpret_cast<const uint8_t*>(data.data());
+  std::size_t remaining = data.size();
+
+  while (remaining >= 64) {
+    sha256_compress(h, p);
+    p += 64;
+    remaining -= 64;
+  }
+
+  uint8_t tail[128] = {};
+  std::memcpy(tail, p, remaining);
+  tail[remaining] = 0x80;
+  std::size_t pad_end = (remaining < 56) ? 64 : 128;
+  for (int i = 0; i < 8; ++i) {
+    tail[pad_end - 1 - i] = static_cast<uint8_t>(bit_len >> (i * 8));
+  }
+  sha256_compress(h, tail);
+  if (pad_end == 128) sha256_compress(h, tail + 64);
+
+  static constexpr char hex[] = "0123456789abcdef";
+  std::string out(64, '0');
+  for (int i = 0; i < 8; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      uint8_t byte = static_cast<uint8_t>(h[i] >> ((3 - j) * 8));
+      out[i * 8 + j * 2] = hex[byte >> 4];
+      out[i * 8 + j * 2 + 1] = hex[byte & 0xf];
+    }
+  }
+  return out;
+}
+
+}  // namespace larch

--- a/test/checkpoint_integration.sh
+++ b/test/checkpoint_integration.sh
@@ -1,0 +1,205 @@
+#!/bin/sh
+# Integration test for larch2 checkpoint/resume.
+#
+# Verifies (against issue #39's test plan):
+#   3. Phase-1-style resume produces a final score ≤ uninterrupted final score.
+#   4. Phase 2 deterministic resume — for every K in {1, 2, 3} on a 6-iteration
+#      run with --seed 42 --checkpoint-after 1, the resumed run produces a
+#      final DAG byte-equal to the uninterrupted run, AND every per-iteration
+#      parsimony score in the results vector matches.
+#   6. Args fingerprint mismatch — resuming with a different --patience exits
+#      non-zero with an error message naming the conflicting field.
+#   7. Multi-resume chain — kill at K=2, resume, kill at K=4, resume to
+#      completion; final output byte-equals the uninterrupted run.
+#   8. Forbidden input flag on resume — --resume + --vcf exits non-zero.
+#
+# Usage: checkpoint_integration.sh <path-to-larch2> <path-to-dag_canonical_equal>
+
+set -e
+
+LARCH2="$1"
+CANON="$2"
+if [ -z "$LARCH2" ] || [ -z "$CANON" ]; then
+    echo "usage: $0 <path-to-larch2> <path-to-dag_canonical_equal>" >&2
+    exit 1
+fi
+
+FIXTURE="data/testcase/full_dag.pb.gz"
+if [ ! -f "$FIXTURE" ]; then
+    echo "missing fixture: $FIXTURE" >&2
+    exit 1
+fi
+
+TMP=$(mktemp -d)
+trap "rm -rf $TMP" EXIT
+
+# Helper: run larch2 quietly, fail on non-zero exit.
+run_larch() {
+    "$LARCH2" "$@" > "$TMP/log.out" 2>&1 || {
+        echo "larch2 failed; args: $*" >&2
+        cat "$TMP/log.out" >&2
+        exit 1
+    }
+}
+
+# Helper: extract per-iteration parsimony scores from the run log.
+extract_scores() {
+    grep -oE "score=[0-9]+ " "$1" | sed 's/score=//;s/ //'
+}
+
+echo "=== Test: uninterrupted baseline ==="
+run_larch --dag-pb "$FIXTURE" --iterations 6 --checkpoint-after 1 \
+    --seed 42 -o "$TMP/baseline.pb.gz" --checkpoint-prefix "$TMP/baseline"
+cp "$TMP/log.out" "$TMP/baseline.log"
+BASELINE_SCORES=$(extract_scores "$TMP/baseline.log")
+echo "baseline scores: $BASELINE_SCORES"
+
+# Phase 2 gate: for each K in {1, 2, 3}, resume from ckpt-K and verify the
+# final output byte-equals the uninterrupted baseline. (Byte equality is
+# achievable because we preserve phylo_dag node/edge ordering through
+# save_proto_dag/load_proto_dag — which save_proto_dag does once load order
+# is forced to match.)
+echo "=== Test: Phase 2 deterministic resume ==="
+for K in 1 2 3; do
+    rm -f "$TMP/resumed_${K}.pb.gz"
+    run_larch --resume "$TMP/baseline.ckpt-${K}.pb.gz" \
+        --iterations 6 --seed 42 -o "$TMP/resumed_${K}.pb.gz" \
+        --checkpoint-prefix "$TMP/resumed_${K}"
+    cp "$TMP/log.out" "$TMP/resumed_${K}.log"
+
+    if ! "$CANON" "$TMP/baseline.pb.gz" "$TMP/resumed_${K}.pb.gz"; then
+        echo "FAIL: resumed_${K}.pb.gz canonical-differs from baseline.pb.gz" >&2
+        exit 1
+    fi
+
+    RESUMED_SCORES=$(extract_scores "$TMP/resumed_${K}.log")
+    if [ "$BASELINE_SCORES" != "$RESUMED_SCORES" ]; then
+        echo "FAIL: resumed_${K} scores ($RESUMED_SCORES) differ from baseline ($BASELINE_SCORES)" >&2
+        exit 1
+    fi
+    echo "  K=$K: canonical-equal, scores match"
+done
+
+# Multi-resume chain: resume from baseline.ckpt-2, write fresh checkpoints,
+# then resume from one of those fresh checkpoints to completion. iterations
+# stays at the baseline value so the args fingerprint check passes.  This
+# catches any RNG-state non-idempotency where serialize -> deserialize ->
+# serialize drifts (the second deserialization runs on a state that itself
+# came from a deserialization round-trip).
+echo "=== Test: multi-resume chain ==="
+run_larch --resume "$TMP/baseline.ckpt-2.pb.gz" \
+    --iterations 6 --seed 42 -o "$TMP/chain1.pb.gz" \
+    --checkpoint-prefix "$TMP/chain1" --checkpoint-after 1
+run_larch --resume "$TMP/chain1.ckpt-4.pb.gz" \
+    --iterations 6 --seed 42 -o "$TMP/chain2.pb.gz" \
+    --checkpoint-prefix "$TMP/chain2"
+if ! "$CANON" "$TMP/baseline.pb.gz" "$TMP/chain2.pb.gz"; then
+    echo "FAIL: chained-resume canonical-differs from baseline" >&2
+    exit 1
+fi
+echo "  multi-resume chain canonical-equal"
+
+# Phase 1 contract: the score after resume is ≤ baseline's final score on the
+# same fixture (resume should never make things worse). Since Phase 2 produces
+# byte-equal output, this trivially holds, but the assertion guards Phase 1
+# regressions if someone reverts the deterministic-resume path.
+echo "=== Test: Phase 1 score-no-worse-than-baseline ==="
+BASELINE_FINAL=$(echo "$BASELINE_SCORES" | tail -1)
+for K in 1 2 3; do
+    R_FINAL=$(extract_scores "$TMP/resumed_${K}.log" | tail -1)
+    if [ "$R_FINAL" -gt "$BASELINE_FINAL" ]; then
+        echo "FAIL: resumed_${K} final score ($R_FINAL) > baseline ($BASELINE_FINAL)" >&2
+        exit 1
+    fi
+done
+echo "  resume final score ≤ baseline final score"
+
+# Args fingerprint mismatch: --patience differs between checkpoint and runtime
+# args. Must exit non-zero and name "patience" as the differing field.
+echo "=== Test: args fingerprint mismatch ==="
+# First make a checkpoint with --patience set so the mismatch on resume is
+# meaningful.
+run_larch --dag-pb "$FIXTURE" --iterations 4 --checkpoint-after 2 \
+    --seed 42 --patience 3 -o "$TMP/p3_out.pb.gz" \
+    --checkpoint-prefix "$TMP/p3"
+
+if "$LARCH2" --resume "$TMP/p3.ckpt-2.pb.gz" --iterations 4 --seed 42 \
+    --patience 99 -o "$TMP/p99.pb.gz" > "$TMP/log.out" 2>&1; then
+    echo "FAIL: expected non-zero exit on patience mismatch" >&2
+    cat "$TMP/log.out" >&2
+    exit 1
+fi
+if ! grep -q "patience" "$TMP/log.out"; then
+    echo "FAIL: error message did not mention 'patience'" >&2
+    cat "$TMP/log.out" >&2
+    exit 1
+fi
+echo "  patience-mismatch refused with the right error"
+
+# Forbidden input flag with --resume.
+echo "=== Test: --resume rejects input flags ==="
+if "$LARCH2" --resume "$TMP/baseline.ckpt-1.pb.gz" --vcf /dev/null \
+    -o "$TMP/forbidden.pb.gz" > "$TMP/log.out" 2>&1; then
+    echo "FAIL: expected non-zero exit on --resume + --vcf" >&2
+    cat "$TMP/log.out" >&2
+    exit 1
+fi
+if ! grep -q -- "--vcf" "$TMP/log.out"; then
+    echo "FAIL: error message did not mention --vcf" >&2
+    cat "$TMP/log.out" >&2
+    exit 1
+fi
+echo "  --resume + --vcf refused"
+
+# Pre-drift checkpoint: triggering drift entry should produce a
+# *.ckpt-<K>-pre-drift.pb.gz file. With --patience 2 --drift 1, the score
+# plateau at 75 will exhaust patience after iter 3 and trigger a drift entry,
+# at which point the worker writes the pre-drift checkpoint.
+echo "=== Test: pre-drift checkpoint ==="
+rm -f "$TMP"/drift.*
+run_larch --dag-pb "$FIXTURE" --iterations 8 --patience 2 --drift 1 \
+    --seed 42 --checkpoint-after 1 -o "$TMP/drift.pb.gz" \
+    --checkpoint-prefix "$TMP/drift"
+PRE_DRIFT=$(ls "$TMP"/drift.ckpt-*-pre-drift.pb.gz 2>/dev/null || true)
+if [ -z "$PRE_DRIFT" ]; then
+    echo "FAIL: expected a pre-drift checkpoint with --patience 2 --drift 1" >&2
+    cat "$TMP/log.out" >&2
+    exit 1
+fi
+echo "  pre-drift checkpoint present: $(basename $PRE_DRIFT)"
+
+# A baseline run (no --patience / no --drift) must NOT write any pre-drift
+# checkpoint files.
+if ls "$TMP"/baseline.ckpt-*-pre-drift.pb.gz >/dev/null 2>&1; then
+    echo "FAIL: unexpected pre-drift checkpoint without --drift" >&2
+    exit 1
+fi
+echo "  no spurious pre-drift checkpoint"
+
+# Higher-than-supported schema_version is rejected. We synthesize a minimal
+# checkpoint with schema_version=999 by editing the first 2 bytes of an
+# existing checkpoint (tag 0x08 + varint 0xe7 0x07).
+echo "=== Test: schema_version too new is rejected ==="
+python3 - "$TMP/baseline.ckpt-1.pb.gz" "$TMP/future.pb.gz" <<'PY'
+import sys, gzip
+src, dst = sys.argv[1], sys.argv[2]
+data = open(src, 'rb').read()
+# data[0] == 0x08 (tag for schema_version varint), data[1] == 0x01
+# Replace the schema_version byte with 0x7f (varint 127, single-byte).
+assert data[0] == 0x08, "expected tag 0x08 at offset 0"
+out = bytes([0x08, 0x7f]) + data[2:]
+open(dst, 'wb').write(out)
+PY
+if "$LARCH2" --resume "$TMP/future.pb.gz" --iterations 1 --seed 42 \
+    -o "$TMP/future_out.pb.gz" > "$TMP/log.out" 2>&1; then
+    echo "FAIL: expected non-zero exit on future schema_version" >&2
+    exit 1
+fi
+if ! grep -qi "schema_version" "$TMP/log.out"; then
+    echo "FAIL: error message did not mention schema_version" >&2
+    cat "$TMP/log.out" >&2
+    exit 1
+fi
+echo "  future schema_version refused"
+
+echo "=== ALL CHECKPOINT INTEGRATION TESTS PASSED ==="

--- a/test/checkpoint_integration.sh
+++ b/test/checkpoint_integration.sh
@@ -52,6 +52,11 @@ run_larch --dag-pb "$FIXTURE" --iterations 6 --checkpoint-after 1 \
     --seed 42 -o "$TMP/baseline.pb.gz" --checkpoint-prefix "$TMP/baseline"
 cp "$TMP/log.out" "$TMP/baseline.log"
 BASELINE_SCORES=$(extract_scores "$TMP/baseline.log")
+if [ -z "$BASELINE_SCORES" ]; then
+    echo "FAIL: baseline run produced no per-iteration scores; log format may have changed" >&2
+    cat "$TMP/baseline.log" >&2
+    exit 1
+fi
 echo "baseline scores: $BASELINE_SCORES"
 
 # Phase 2 gate: for each K in {1, 2, 3}, resume from ckpt-K and verify the
@@ -60,7 +65,9 @@ echo "baseline scores: $BASELINE_SCORES"
 # save_proto_dag/load_proto_dag — which save_proto_dag does once load order
 # is forced to match.)
 echo "=== Test: Phase 2 deterministic resume ==="
-for K in 1 2 3; do
+# Cover every interrupt point K ∈ [1, N-1] from the issue's "every-iteration
+# interrupt" property test (issue #39 test plan #9).
+for K in 1 2 3 4 5; do
     rm -f "$TMP/resumed_${K}.pb.gz"
     run_larch --resume "$TMP/baseline.ckpt-${K}.pb.gz" \
         --iterations 6 --seed 42 -o "$TMP/resumed_${K}.pb.gz" \
@@ -105,7 +112,7 @@ echo "  multi-resume chain canonical-equal"
 # regressions if someone reverts the deterministic-resume path.
 echo "=== Test: Phase 1 score-no-worse-than-baseline ==="
 BASELINE_FINAL=$(echo "$BASELINE_SCORES" | tail -1)
-for K in 1 2 3; do
+for K in 1 2 3 4 5; do
     R_FINAL=$(extract_scores "$TMP/resumed_${K}.log" | tail -1)
     if [ "$R_FINAL" -gt "$BASELINE_FINAL" ]; then
         echo "FAIL: resumed_${K} final score ($R_FINAL) > baseline ($BASELINE_FINAL)" >&2
@@ -136,20 +143,25 @@ if ! grep -q "patience" "$TMP/log.out"; then
 fi
 echo "  patience-mismatch refused with the right error"
 
-# Forbidden input flag with --resume.
+# Forbidden input flags with --resume. Cover the input flags most likely to
+# be re-passed by mistake: --vcf (issue's specific test 8) and --dag-pb (the
+# common case where a user forgets the flag-swap).
 echo "=== Test: --resume rejects input flags ==="
-if "$LARCH2" --resume "$TMP/baseline.ckpt-1.pb.gz" --vcf /dev/null \
-    -o "$TMP/forbidden.pb.gz" > "$TMP/log.out" 2>&1; then
-    echo "FAIL: expected non-zero exit on --resume + --vcf" >&2
-    cat "$TMP/log.out" >&2
-    exit 1
-fi
-if ! grep -q -- "--vcf" "$TMP/log.out"; then
-    echo "FAIL: error message did not mention --vcf" >&2
-    cat "$TMP/log.out" >&2
-    exit 1
-fi
-echo "  --resume + --vcf refused"
+for FORBIDDEN_FLAG in --vcf --dag-pb; do
+    if "$LARCH2" --resume "$TMP/baseline.ckpt-1.pb.gz" \
+        "$FORBIDDEN_FLAG" /dev/null -o "$TMP/forbidden.pb.gz" \
+        > "$TMP/log.out" 2>&1; then
+        echo "FAIL: expected non-zero exit on --resume + $FORBIDDEN_FLAG" >&2
+        cat "$TMP/log.out" >&2
+        exit 1
+    fi
+    if ! grep -q -- "$FORBIDDEN_FLAG" "$TMP/log.out"; then
+        echo "FAIL: error message did not mention $FORBIDDEN_FLAG" >&2
+        cat "$TMP/log.out" >&2
+        exit 1
+    fi
+    echo "  --resume + $FORBIDDEN_FLAG refused"
+done
 
 # Pre-drift checkpoint: triggering drift entry should produce a
 # *.ckpt-<K>-pre-drift.pb.gz file. With --patience 2 --drift 1, the score

--- a/test/checkpoint_test.cpp
+++ b/test/checkpoint_test.cpp
@@ -46,13 +46,13 @@ static void test_checkpoint_msg_roundtrip() {
   for (int i = 0; i < 10; ++i) (void)rng();
   c.main_rng.mt19937_state = serialize_mt19937(rng);
 
-  optimize_result_msg_pb r{};
+  optimize_result_msg r{};
   r.iteration = 0;
   r.dag_node_count = 10;
   r.dag_edge_count = 9;
   r.trees_merged = 1;
   r.parsimony_score = 100;
-  radius_result_msg_pb rd{};
+  radius_result_msg rd{};
   rd.radius = 2;
   rd.moves_found = 3;
   rd.moves_applied = 2;

--- a/test/checkpoint_test.cpp
+++ b/test/checkpoint_test.cpp
@@ -1,0 +1,141 @@
+// Unit tests for the checkpoint serialization layer:
+//   1. mt19937 round-trip via std::ostringstream / operator<< — must match
+//      bit-exact (the C++ standard guarantees this and the resume path
+//      relies on it).
+//   2. larch_checkpoint_msg round-trip — write the proto bytes and decode
+//      them back, asserting every scalar field plus nested results /
+//      patience / dag survive intact.
+//   3. SHA-256 — verify the empty-string and "abc" KATs from FIPS 180-4 so
+//      a future change to the digest doesn't silently break the args
+//      fingerprint check.
+
+#include <larch/checkpoint.hpp>
+
+#include <cassert>
+#include <cstdio>
+#include <print>
+#include <random>
+#include <string>
+
+using namespace larch;
+
+static void test_mt19937_roundtrip() {
+  std::mt19937 rng{12345};
+  for (int i = 0; i < 1000; ++i) (void)rng();
+  auto serialized = serialize_mt19937(rng);
+  auto restored = deserialize_mt19937(serialized);
+  for (int i = 0; i < 100; ++i) {
+    auto a = rng();
+    auto b = restored();
+    assert(a == b);
+  }
+  std::println("test_mt19937_roundtrip: OK");
+}
+
+static void test_checkpoint_msg_roundtrip() {
+  larch_checkpoint_msg c{};
+  c.schema_version = checkpoint_schema_version;
+  c.larch2_git_sha = "abc123";
+  c.next_iteration = 5;
+  c.optimizer = "native";
+  c.patience.limit = 3;
+  c.patience.count = 1;
+  c.patience.best_score = 100;
+
+  std::mt19937 rng{42};
+  for (int i = 0; i < 10; ++i) (void)rng();
+  c.main_rng.mt19937_state = serialize_mt19937(rng);
+
+  optimize_result_msg_pb r{};
+  r.iteration = 0;
+  r.dag_node_count = 10;
+  r.dag_edge_count = 9;
+  r.trees_merged = 1;
+  r.parsimony_score = 100;
+  radius_result_msg_pb rd{};
+  rd.radius = 2;
+  rd.moves_found = 3;
+  rd.moves_applied = 2;
+  rd.parsimony_score = 100;
+  r.radii.push_back(rd);
+  c.results.push_back(r);
+
+  c.dag.reference_seq = "ACGT";
+  c.dag.reference_id = "ref";
+  c.args_fingerprint = "deadbeef";
+  c.args_payload = "{\"k\":\"v\"}";
+
+  auto bytes = pb::encode(c);
+  std::span<const uint8_t> span{bytes.data(), bytes.size()};
+  assert(looks_like_checkpoint(span));
+
+  auto decoded = pb::decode<larch_checkpoint_msg>(span);
+  assert(decoded.schema_version == c.schema_version);
+  assert(decoded.larch2_git_sha == c.larch2_git_sha);
+  assert(decoded.next_iteration == c.next_iteration);
+  assert(decoded.optimizer == c.optimizer);
+  assert(decoded.patience.limit == c.patience.limit);
+  assert(decoded.patience.count == c.patience.count);
+  assert(decoded.patience.best_score == c.patience.best_score);
+  assert(decoded.main_rng.mt19937_state == c.main_rng.mt19937_state);
+  assert(decoded.drift_rng.mt19937_state.empty());
+  assert(decoded.results.size() == 1);
+  assert(decoded.results[0].dag_node_count == 10);
+  assert(decoded.results[0].radii.size() == 1);
+  assert(decoded.results[0].radii[0].radius == 2);
+  assert(decoded.dag.reference_seq == "ACGT");
+  assert(decoded.dag.reference_id == "ref");
+  assert(decoded.args_fingerprint == "deadbeef");
+  assert(decoded.args_payload == "{\"k\":\"v\"}");
+
+  // Restore RNG and verify it produces identical draws.
+  auto restored = deserialize_mt19937(decoded.main_rng.mt19937_state);
+  for (int i = 0; i < 100; ++i) {
+    assert(rng() == restored());
+  }
+  std::println("test_checkpoint_msg_roundtrip: OK");
+}
+
+static void test_sha256_known_vectors() {
+  // FIPS 180-4 known answer tests
+  assert(sha256_hex("") ==
+         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  assert(sha256_hex("abc") ==
+         "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+  std::println("test_sha256_known_vectors: OK");
+}
+
+static void test_optional_int64_present_zero() {
+  // optional<int64_t> = 0 must round-trip as 0 (not absent), distinct from
+  // optional<int64_t> = nullopt. The patience_state requires this to
+  // distinguish "best_score has been observed, and it's 0" from "no best_score
+  // recorded yet".
+  patience_state_msg p{};
+  p.limit = 0;
+  p.count = 0;
+  p.best_score = 0;
+  auto bytes = pb::encode(p);
+  auto decoded = pb::decode<patience_state_msg>({bytes.data(), bytes.size()});
+  assert(decoded.limit.has_value() && *decoded.limit == 0);
+  assert(decoded.count == 0);
+  assert(decoded.best_score.has_value() && *decoded.best_score == 0);
+
+  patience_state_msg q{};
+  q.count = 5;
+  // limit and best_score left as nullopt
+  auto b2 = pb::encode(q);
+  auto d2 = pb::decode<patience_state_msg>({b2.data(), b2.size()});
+  assert(!d2.limit.has_value());
+  assert(d2.count == 5);
+  assert(!d2.best_score.has_value());
+  std::println("test_optional_int64_present_zero: OK");
+}
+
+int main() {
+  test_mt19937_roundtrip();
+  test_checkpoint_msg_roundtrip();
+  test_sha256_known_vectors();
+  test_optional_int64_present_zero();
+  std::println("all checkpoint tests passed");
+  return 0;
+}

--- a/test/checkpoint_test.cpp
+++ b/test/checkpoint_test.cpp
@@ -80,9 +80,18 @@ static void test_checkpoint_msg_roundtrip() {
   assert(decoded.main_rng.mt19937_state == c.main_rng.mt19937_state);
   assert(decoded.drift_rng.mt19937_state.empty());
   assert(decoded.results.size() == 1);
-  assert(decoded.results[0].dag_node_count == 10);
+  // Every result + radius field must round-trip; a regression that silently
+  // zero-initialises any of these would also let determinism quietly drift.
+  assert(decoded.results[0].iteration == r.iteration);
+  assert(decoded.results[0].dag_node_count == r.dag_node_count);
+  assert(decoded.results[0].dag_edge_count == r.dag_edge_count);
+  assert(decoded.results[0].trees_merged == r.trees_merged);
+  assert(decoded.results[0].parsimony_score == r.parsimony_score);
   assert(decoded.results[0].radii.size() == 1);
-  assert(decoded.results[0].radii[0].radius == 2);
+  assert(decoded.results[0].radii[0].radius == rd.radius);
+  assert(decoded.results[0].radii[0].moves_found == rd.moves_found);
+  assert(decoded.results[0].radii[0].moves_applied == rd.moves_applied);
+  assert(decoded.results[0].radii[0].parsimony_score == rd.parsimony_score);
   assert(decoded.dag.reference_seq == "ACGT");
   assert(decoded.dag.reference_id == "ref");
   assert(decoded.args_fingerprint == "deadbeef");
@@ -131,11 +140,45 @@ static void test_optional_int64_present_zero() {
   std::println("test_optional_int64_present_zero: OK");
 }
 
+// Drift_rng is emitted by encoding only when its mt19937_state is
+// non-empty. Verify that a populated drift_rng survives the round-trip
+// distinct from main_rng — this is the field that would matter most if a
+// future change captured in-progress drift state at checkpoint time.
+static void test_drift_rng_roundtrip() {
+  larch_checkpoint_msg c{};
+  c.schema_version = checkpoint_schema_version;
+  c.optimizer = "native";
+
+  std::mt19937 main_rng{1};
+  std::mt19937 drift_rng{2};
+  for (int i = 0; i < 5; ++i) (void)main_rng();
+  for (int i = 0; i < 11; ++i) (void)drift_rng();
+  c.main_rng.mt19937_state = serialize_mt19937(main_rng);
+  c.drift_rng.mt19937_state = serialize_mt19937(drift_rng);
+
+  auto bytes = pb::encode(c);
+  auto decoded = pb::decode<larch_checkpoint_msg>({bytes.data(), bytes.size()});
+  assert(!decoded.drift_rng.mt19937_state.empty());
+  assert(decoded.drift_rng.mt19937_state == c.drift_rng.mt19937_state);
+  assert(decoded.main_rng.mt19937_state == c.main_rng.mt19937_state);
+  // Different RNGs must remain distinct after the round-trip.
+  assert(decoded.main_rng.mt19937_state != decoded.drift_rng.mt19937_state);
+
+  auto restored_main = deserialize_mt19937(decoded.main_rng.mt19937_state);
+  auto restored_drift = deserialize_mt19937(decoded.drift_rng.mt19937_state);
+  for (int i = 0; i < 50; ++i) {
+    assert(main_rng() == restored_main());
+    assert(drift_rng() == restored_drift());
+  }
+  std::println("test_drift_rng_roundtrip: OK");
+}
+
 int main() {
   test_mt19937_roundtrip();
   test_checkpoint_msg_roundtrip();
   test_sha256_known_vectors();
   test_optional_int64_present_zero();
+  test_drift_rng_roundtrip();
   std::println("all checkpoint tests passed");
   return 0;
 }

--- a/test/dag_canonical_equal.cpp
+++ b/test/dag_canonical_equal.cpp
@@ -1,0 +1,151 @@
+// dag_canonical_equal: small helper for the checkpoint integration test.
+//
+// save_proto_dag does not guarantee any output ordering — node proto-IDs are
+// allocated in dag.get_all_nodes() iteration order, which depends on the
+// internal merge state. Two runs that produce logically equivalent DAGs can
+// therefore produce .pb.gz files that differ in node IDs even though the
+// underlying topology and mutations match.
+//
+// This tool loads both files via load_proto_dag (which gives us a phylo_dag
+// with computed compact-genome strings), assigns each node a content-based
+// canonical key — for leaves the sample_id, for inner nodes the
+// compact-genome string — and rewrites every edge as a tuple of canonical
+// parent key, parent clade, canonical child key, and a sorted multiset of
+// mutations. Two DAGs are canonically equal iff their multisets of these
+// canonical edge tuples match exactly.
+//
+// Usage: dag_canonical_equal <a.pb.gz> <b.pb.gz>
+// Exit:  0 if canonical-equal, 1 otherwise.
+
+#include <larch/load_proto_dag.hpp>
+
+#include <algorithm>
+#include <iostream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <variant>
+#include <vector>
+
+using namespace larch;
+
+namespace {
+
+std::string node_canonical_key(phylo_dag& d, std::size_t idx) {
+  auto nv = d.get_node(idx);
+  return std::visit(
+      [](auto n) -> std::string {
+        if constexpr (requires { n.reference_sequence(); }) {
+          return "UA";
+        } else if constexpr (requires { n.sample_id(); n.cg(); }) {
+          // Leaf: sample_id alone is unique inside a merge.
+          return "L:" + std::string{n.sample_id()};
+        } else if constexpr (requires { n.cg(); }) {
+          return "I:" + n.cg().to_string();
+        } else {
+          return "?";
+        }
+      },
+      nv);
+}
+
+// Serialize each edge as a comparable string. Format:
+//   <parent_key>|<parent_clade>|<child_key>|<sorted-mutations>
+// where mutations are joined as "pos:par_nuc->mut_nuc" tokens in sorted
+// order.
+std::string edge_signature(phylo_dag& d, std::size_t edge_idx) {
+  auto ev = d.get_edge(edge_idx);
+  return std::visit(
+      [&](auto edge) {
+        auto p_idx =
+            std::visit([](auto n) { return n.index(); }, edge.get_parent());
+        auto c_idx =
+            std::visit([](auto n) { return n.index(); }, edge.get_child());
+        std::string p_key = node_canonical_key(d, p_idx);
+        std::string c_key = node_canonical_key(d, c_idx);
+        std::vector<std::string> mut_strs;
+        for (auto& [pos, nucs] : edge.mutations()) {
+          std::ostringstream s;
+          s << pos << ':' << static_cast<int>(nucs.first.raw()) << "->"
+            << static_cast<int>(nucs.second.raw());
+          mut_strs.push_back(s.str());
+        }
+        std::sort(mut_strs.begin(), mut_strs.end());
+        std::ostringstream out;
+        out << p_key << '|' << edge.clade_index() << '|' << c_key << '|';
+        for (std::size_t i = 0; i < mut_strs.size(); ++i) {
+          if (i) out << ',';
+          out << mut_strs[i];
+        }
+        return out.str();
+      },
+      ev);
+}
+
+std::vector<std::string> all_edge_signatures(phylo_dag& d) {
+  std::vector<std::string> sigs;
+  for (auto ev : d.get_all_edges()) {
+    auto idx = std::visit([](auto e) { return e.index(); }, ev);
+    sigs.push_back(edge_signature(d, idx));
+  }
+  std::sort(sigs.begin(), sigs.end());
+  return sigs;
+}
+
+std::vector<std::string> all_node_keys(phylo_dag& d) {
+  std::vector<std::string> keys;
+  for (auto nv : d.get_all_nodes()) {
+    auto idx = std::visit([](auto n) { return n.index(); }, nv);
+    keys.push_back(node_canonical_key(d, idx));
+  }
+  std::sort(keys.begin(), keys.end());
+  return keys;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  if (argc != 3) {
+    std::cerr << "usage: dag_canonical_equal <a.pb.gz> <b.pb.gz>\n";
+    return 2;
+  }
+  auto da = load_proto_dag(argv[1]);
+  auto db = load_proto_dag(argv[2]);
+
+  if (get_reference_sequence(da) != get_reference_sequence(db)) {
+    std::cerr << "dag_canonical_equal: differ (reference sequence)\n";
+    return 1;
+  }
+
+  auto a_nodes = all_node_keys(da);
+  auto b_nodes = all_node_keys(db);
+  if (a_nodes != b_nodes) {
+    std::cerr << "dag_canonical_equal: differ (node-key multiset; "
+              << a_nodes.size() << " vs " << b_nodes.size() << ")\n";
+    return 1;
+  }
+
+  auto a_edges = all_edge_signatures(da);
+  auto b_edges = all_edge_signatures(db);
+  if (a_edges != b_edges) {
+    std::cerr << "dag_canonical_equal: differ (edge-signature multiset; "
+              << a_edges.size() << " vs " << b_edges.size() << ")\n";
+    // Print a few divergent signatures to aid debugging.
+    std::set<std::string> as{a_edges.begin(), a_edges.end()};
+    std::set<std::string> bs{b_edges.begin(), b_edges.end()};
+    std::size_t shown = 0;
+    for (auto& s : as) {
+      if (!bs.contains(s) && shown++ < 3)
+        std::cerr << "  only in a: " << s << "\n";
+    }
+    shown = 0;
+    for (auto& s : bs) {
+      if (!as.contains(s) && shown++ < 3)
+        std::cerr << "  only in b: " << s << "\n";
+    }
+    return 1;
+  }
+
+  return 0;
+}

--- a/tools/larch2.cpp
+++ b/tools/larch2.cpp
@@ -1,6 +1,7 @@
 #include <larch/load_proto_dag.hpp>
 #include <larch/load_parsimony.hpp>
 #include <larch/save_proto_dag.hpp>
+#include <larch/checkpoint.hpp>
 #include <larch/fasta.hpp>
 #include <larch/vcf.hpp>
 #include <larch/merge.hpp>
@@ -389,6 +390,16 @@ Diverse tree extraction:
   --diverse-pool <N>      Override pool size (default: max(10K, 100))
   --diverse-newick <path> Write selected trees as Newick strings (one per line)
 
+Checkpointing:
+  --checkpoint-after <N>  Write a checkpoint every N completed iterations
+                          (and immediately before each drift-escape entry in
+                          the native optimizer)
+  --checkpoint-prefix <P> Override checkpoint path prefix (default: derived
+                          from --output by stripping .pb.gz)
+  --resume <path>         Resume from a checkpoint file. Mutually exclusive
+                          with all input flags (--dag-pb, --tree-pb,
+                          --fasta, --newick, --refseq, --vcf).
+
 Post-processing:
   --trim                  Trim result to minimum-parsimony trees
 
@@ -443,7 +454,32 @@ struct args {
   fragment_strategy inplace_fragments = fragment_strategy::final_only;
   drift_mode_t drift_mode = drift_mode_t::auto_;
   std::optional<std::uint32_t> drift_seed;
+  std::optional<std::size_t> checkpoint_after;
+  std::string checkpoint_prefix;
+  std::string resume;
 };
+
+// Strip a trailing ".pb.gz" or ".pb" from a path so checkpoints can be
+// named "<prefix>.ckpt-<iter>.pb.gz".
+static std::string strip_pb_suffix(std::string_view path) {
+  std::string s{path};
+  for (std::string_view suf : {".pb.gz", ".pb"}) {
+    if (s.size() >= suf.size() &&
+        s.compare(s.size() - suf.size(), suf.size(), suf) == 0) {
+      s.resize(s.size() - suf.size());
+      break;
+    }
+  }
+  return s;
+}
+
+static std::string checkpoint_filename(std::string const& prefix,
+                                       std::size_t iter, bool pre_drift) {
+  std::string out = prefix + ".ckpt-" + std::to_string(iter);
+  if (pre_drift) out += "-pre-drift";
+  out += ".pb.gz";
+  return out;
+}
 
 static args parse_args(int argc, char** argv) {
   args a;
@@ -553,6 +589,17 @@ static args parse_args(int argc, char** argv) {
     } else if (arg == "--drift-seed") {
       a.drift_seed = static_cast<std::uint32_t>(
           std::stoull(std::string{next()}, nullptr, 0));
+    } else if (arg == "--checkpoint-after") {
+      auto n = std::stoull(std::string{next()});
+      if (n == 0) {
+        std::cerr << "error: --checkpoint-after must be >= 1\n";
+        std::exit(1);
+      }
+      a.checkpoint_after = n;
+    } else if (arg == "--checkpoint-prefix") {
+      a.checkpoint_prefix = next();
+    } else if (arg == "--resume") {
+      a.resume = next();
     } else if (arg == "--version") {
       std::cerr << "larch2 " << larch::version << " (" << larch::git_commit
                 << ")\n";
@@ -570,6 +617,28 @@ static args parse_args(int argc, char** argv) {
     std::cerr << "error: --output/-o is required\n";
     usage();
     std::exit(1);
+  }
+  if (!a.resume.empty()) {
+    // --resume is mutually exclusive with all input flags. The checkpoint is
+    // self-describing (the merged DAG already contains every input mutation,
+    // including VCF-driven leaf ambiguity), so re-passing them would
+    // double-apply.
+    struct {
+      std::string_view name;
+      std::string const& value;
+    } const inputs[] = {
+        {"--dag-pb", a.dag_pb}, {"--tree-pb", a.tree_pb},
+        {"--fasta", a.fasta},   {"--newick", a.newick},
+        {"--refseq", a.refseq}, {"--vcf", a.vcf},
+    };
+    for (auto& in : inputs) {
+      if (!in.value.empty()) {
+        std::cerr << "error: " << in.name
+                  << " is forbidden with --resume (checkpoint is "
+                     "self-describing)\n";
+        std::exit(1);
+      }
+    }
   }
   return a;
 }
@@ -1632,24 +1701,292 @@ static bool drift_escape(merge& m, args const& a, progress& prog) {
 }
 
 // ---------------------------------------------------------------------------
+// Checkpointing
+// ---------------------------------------------------------------------------
+
+// JSON-encoded payload of the args fields whose values affect the
+// optimization trajectory. The payload is hashed (SHA-256) into the stored
+// args_fingerprint and also stored verbatim alongside the digest so a
+// mismatch on resume can name the differing fields.
+static std::string args_fingerprint_payload(args const& a) {
+  auto opt_u = [](std::optional<std::uint32_t> const& v) {
+    return v ? std::to_string(*v) : std::string{"null"};
+  };
+  auto opt_z = [](std::optional<std::size_t> const& v) {
+    return v ? std::to_string(*v) : std::string{"null"};
+  };
+  auto opt_i = [](std::optional<int> const& v) {
+    return v ? std::to_string(*v) : std::string{"null"};
+  };
+  auto j_bool = [](bool b) { return b ? "true" : "false"; };
+  auto j_str = [](std::string_view s) { return "\"" + std::string{s} + "\""; };
+  auto frag_to_str = [](fragment_strategy fs) {
+    return fs == fragment_strategy::every_step ? "every" : "final";
+  };
+  auto drift_to_str = [](drift_mode_t m) {
+    switch (m) {
+      case drift_mode_t::auto_:       return "auto";
+      case drift_mode_t::legacy:      return "legacy";
+      case drift_mode_t::inplace:     return "inplace";
+      case drift_mode_t::combine:     return "combine";
+      case drift_mode_t::combine_lwf: return "combine-lwf";
+    }
+    return "auto";
+  };
+
+  std::ostringstream os;
+  os << "{";
+  os << "\"iterations\":" << a.iterations;
+  os << ",\"optimizer\":" << j_str(a.optimizer);
+  os << ",\"max_moves\":" << a.max_moves;
+  os << ",\"seed\":" << opt_u(a.seed);
+  os << ",\"sample_method\":" << j_str(a.sample_method);
+  os << ",\"sample_uniformly\":" << j_bool(a.sample_uniformly);
+  os << ",\"sample_per_radius\":" << j_bool(a.sample_per_radius);
+  os << ",\"ignore_root_edge_mutations\":"
+     << j_bool(a.ignore_root_edge_mutations);
+  os << ",\"callback_option\":" << j_str(a.callback_option);
+  os << ",\"switch_subtrees\":" << opt_z(a.switch_subtrees);
+  os << ",\"min_subtree_clade_size\":" << a.min_subtree_clade_size;
+  os << ",\"max_subtree_clade_size\":" << a.max_subtree_clade_size;
+  os << ",\"move_coeff_pscore\":" << a.move_coeff_pscore;
+  os << ",\"move_coeff_nodes\":" << a.move_coeff_nodes;
+  os << ",\"move_score_threshold\":" << opt_i(a.move_score_threshold);
+  os << ",\"patience\":" << opt_z(a.patience);
+  os << ",\"drift\":" << opt_z(a.drift);
+  os << ",\"inplace_steps\":" << a.inplace_steps;
+  os << ",\"inplace_threshold\":" << a.inplace_threshold;
+  os << ",\"inplace_budget\":" << opt_i(a.inplace_budget);
+  os << ",\"inplace_temperature\":" << a.inplace_temperature;
+  os << ",\"inplace_cooling\":" << a.inplace_cooling;
+  os << ",\"inplace_fragments\":" << j_str(frag_to_str(a.inplace_fragments));
+  os << ",\"drift_mode\":" << j_str(drift_to_str(a.drift_mode));
+  os << ",\"drift_seed\":" << opt_u(a.drift_seed);
+  os << "}";
+  return os.str();
+}
+
+// Parse a JSON args_payload back into a flat key->value map for diffing.
+// The payload is generated by us with a known shape, so a minimal hand-rolled
+// parser is enough — values are bare numbers, true/false, null, or quoted
+// strings. No nested objects/arrays.
+static std::map<std::string, std::string> parse_args_payload(
+    std::string_view payload) {
+  std::map<std::string, std::string> out;
+  std::size_t i = 0;
+  auto skip_ws = [&] {
+    while (i < payload.size() &&
+           (payload[i] == ' ' || payload[i] == '\t' || payload[i] == '\n'))
+      ++i;
+  };
+  if (i < payload.size() && payload[i] == '{') ++i;
+  while (i < payload.size()) {
+    skip_ws();
+    if (i >= payload.size() || payload[i] == '}') break;
+    if (payload[i] != '"') break;
+    ++i;
+    std::size_t key_start = i;
+    while (i < payload.size() && payload[i] != '"') ++i;
+    std::string key{payload.substr(key_start, i - key_start)};
+    if (i < payload.size()) ++i;  // closing quote
+    skip_ws();
+    if (i < payload.size() && payload[i] == ':') ++i;
+    skip_ws();
+    std::string value;
+    if (i < payload.size() && payload[i] == '"') {
+      ++i;
+      std::size_t v_start = i;
+      while (i < payload.size() && payload[i] != '"') ++i;
+      value.assign(payload.substr(v_start, i - v_start));
+      if (i < payload.size()) ++i;
+    } else {
+      std::size_t v_start = i;
+      while (i < payload.size() && payload[i] != ',' && payload[i] != '}')
+        ++i;
+      value.assign(payload.substr(v_start, i - v_start));
+      while (!value.empty() &&
+             (value.back() == ' ' || value.back() == '\t' || value.back() == '\n'))
+        value.pop_back();
+    }
+    out[std::move(key)] = std::move(value);
+    skip_ws();
+    if (i < payload.size() && payload[i] == ',') ++i;
+  }
+  return out;
+}
+
+// Resume-state carried across iterations of run_native / run_random.
+struct resume_state {
+  std::size_t next_iteration = 0;
+  std::mt19937 rng;
+  patience_checker patience;
+  std::vector<optimize_result> results;
+};
+
+static resume_state resume_state_from_msg(larch::larch_checkpoint_msg const& c) {
+  resume_state s;
+  s.next_iteration = static_cast<std::size_t>(c.next_iteration);
+  s.rng = larch::deserialize_mt19937(c.main_rng.mt19937_state);
+  if (c.patience.limit) s.patience.limit = static_cast<std::size_t>(*c.patience.limit);
+  s.patience.count = static_cast<std::size_t>(c.patience.count);
+  if (c.patience.best_score)
+    s.patience.best_score = static_cast<std::size_t>(*c.patience.best_score);
+  s.results.reserve(c.results.size());
+  for (auto const& r : c.results) {
+    optimize_result o;
+    o.iteration = static_cast<std::size_t>(r.iteration);
+    o.dag_node_count = static_cast<std::size_t>(r.dag_node_count);
+    o.dag_edge_count = static_cast<std::size_t>(r.dag_edge_count);
+    o.trees_merged = static_cast<std::size_t>(r.trees_merged);
+    o.parsimony_score = static_cast<std::size_t>(r.parsimony_score);
+    o.radii.reserve(r.radii.size());
+    for (auto const& rd : r.radii) {
+      o.radii.push_back(radius_result{
+          .radius = static_cast<std::size_t>(rd.radius),
+          .moves_found = static_cast<std::size_t>(rd.moves_found),
+          .moves_applied = static_cast<std::size_t>(rd.moves_applied),
+          .parsimony_score = static_cast<std::size_t>(rd.parsimony_score),
+      });
+    }
+    s.results.push_back(std::move(o));
+  }
+  return s;
+}
+
+static larch::larch_checkpoint_msg build_checkpoint_msg(
+    merge& m, args const& a, std::size_t completed_iter,
+    std::mt19937 const& rng, patience_checker const& patience,
+    std::vector<optimize_result> const& results) {
+  larch::larch_checkpoint_msg c{};
+  c.schema_version = larch::checkpoint_schema_version;
+  c.larch2_git_sha = larch::git_commit;
+  c.next_iteration = static_cast<int64_t>(completed_iter);
+  c.optimizer = a.optimizer;
+  if (a.patience) c.patience.limit = static_cast<int64_t>(*a.patience);
+  c.patience.count = static_cast<int64_t>(patience.count);
+  if (patience.best_score)
+    c.patience.best_score = static_cast<int64_t>(*patience.best_score);
+  c.main_rng.mt19937_state = larch::serialize_mt19937(rng);
+  // drift_rng is reseeded inside drift_escape from a.drift_seed and is not
+  // captured (no in-progress drift state at our checkpoint sites).
+  c.results.reserve(results.size());
+  for (auto const& r : results) {
+    larch::optimize_result_msg_pb m_r{};
+    m_r.iteration = static_cast<int64_t>(r.iteration);
+    m_r.dag_node_count = static_cast<int64_t>(r.dag_node_count);
+    m_r.dag_edge_count = static_cast<int64_t>(r.dag_edge_count);
+    m_r.trees_merged = static_cast<int64_t>(r.trees_merged);
+    m_r.parsimony_score = static_cast<int64_t>(r.parsimony_score);
+    m_r.radii.reserve(r.radii.size());
+    for (auto const& rd : r.radii) {
+      larch::radius_result_msg_pb m_rd{};
+      m_rd.radius = static_cast<int64_t>(rd.radius);
+      m_rd.moves_found = static_cast<int64_t>(rd.moves_found);
+      m_rd.moves_applied = static_cast<int64_t>(rd.moves_applied);
+      m_rd.parsimony_score = static_cast<int64_t>(rd.parsimony_score);
+      m_r.radii.push_back(std::move(m_rd));
+    }
+    c.results.push_back(std::move(m_r));
+  }
+
+  // Serialize the merged DAG into the checkpoint's nested dag_data field.
+  // We mirror save_proto_dag's logic, but build a dag_data struct directly
+  // instead of writing it to a file.
+  auto& dag = m.get_result();
+  larch::dag_data& data = c.dag;
+  data.reference_seq = get_reference_sequence(dag);
+
+  std::unordered_map<std::size_t, int64_t> node_to_proto;
+  auto root_idx = get_root_idx(dag);
+  node_to_proto[root_idx] = 0;
+  int64_t next_id = 1;
+  for (auto nv : dag.get_all_nodes()) {
+    auto idx = std::visit([](auto n) { return n.index(); }, nv);
+    if (idx == root_idx) continue;
+    node_to_proto[idx] = next_id++;
+  }
+
+  int64_t edge_id = 0;
+  for (auto ev : dag.get_all_edges()) {
+    std::visit(
+        [&](auto edge) {
+          auto parent_idx =
+              std::visit([](auto n) { return n.index(); }, edge.get_parent());
+          auto child_idx =
+              std::visit([](auto n) { return n.index(); }, edge.get_child());
+          larch::dag_edge de;
+          de.edge_id = edge_id++;
+          de.parent_node = node_to_proto[parent_idx];
+          de.child_node = node_to_proto[child_idx];
+          de.parent_clade = static_cast<int64_t>(edge.clade_index());
+          for (auto& [pos, nucs] : edge.mutations()) {
+            larch::dag_mut dm;
+            dm.position = static_cast<int32_t>(pos);
+            dm.par_nuc = static_cast<int32_t>(nucs.first.raw());
+            dm.mut_nuc = {static_cast<int32_t>(nucs.second.raw())};
+            de.edge_mutations.push_back(std::move(dm));
+          }
+          data.edges.push_back(std::move(de));
+        },
+        ev);
+  }
+  for (auto nv : dag.get_all_nodes()) {
+    std::visit(
+        [&](auto node) {
+          larch::dag_node_name nn;
+          nn.node_id = node_to_proto[node.index()];
+          if constexpr (requires { node.sample_id(); })
+            nn.condensed_leaves = {node.sample_id()};
+          data.node_names.push_back(std::move(nn));
+        },
+        nv);
+  }
+
+  c.args_payload = args_fingerprint_payload(a);
+  c.args_fingerprint = larch::sha256_hex(c.args_payload);
+  return c;
+}
+
+// Phase 2 checkpoint write: the merged DAG plus optimization state.
+static void write_full_checkpoint(merge& m, args const& a,
+                                  std::size_t completed_iter, bool pre_drift,
+                                  std::mt19937 const& rng,
+                                  patience_checker const& patience,
+                                  std::vector<optimize_result> const& results) {
+  if (a.checkpoint_prefix.empty()) return;
+  std::string path =
+      checkpoint_filename(a.checkpoint_prefix, completed_iter, pre_drift);
+  auto msg = build_checkpoint_msg(m, a, completed_iter, rng, patience, results);
+  larch::write_checkpoint(msg, path);
+  std::cerr << "  Wrote checkpoint " << path << "\n";
+}
+
+// ---------------------------------------------------------------------------
 // Native optimizer loop with progress
 // ---------------------------------------------------------------------------
 
-static std::vector<optimize_result> run_native(merge& m, args const& a) {
+static std::vector<optimize_result> run_native(
+    merge& m, args const& a,
+    std::optional<resume_state> resume = std::nullopt) {
   auto& pool = thread_pool::get_default();
-  std::mt19937 rng(a.seed.value_or(std::random_device{}()));
+  std::mt19937 rng = resume ? std::move(resume->rng)
+                            : std::mt19937{a.seed.value_or(
+                                  std::random_device{}())};
   std::vector<optimize_result> results;
   results.reserve(a.iterations);
+  std::size_t start_iter = 0;
+  patience_checker patience{a.patience};
+  if (resume) {
+    results = std::move(resume->results);
+    start_iter = resume->next_iteration;
+    patience = std::move(resume->patience);
+  }
   progress prog;
   move_coefficients coeffs{a.move_coeff_pscore, a.move_coeff_nodes};
   int score_threshold =
       a.move_score_threshold.value_or(coeffs.has_node_penalty() ? 0 : -1);
-  // Shared across subtree and whole-tree paths: only one path executes per
-  // iteration (the subtree path ends with `continue`), so the counter
-  // reflects whichever path ran.
-  patience_checker patience{a.patience};
 
-  for (std::size_t iter = 0; iter < a.iterations; ++iter) {
+  for (std::size_t iter = start_iter; iter < a.iterations; ++iter) {
     std::cerr << "Iteration " << (iter + 1) << "/" << a.iterations << ":\n";
 
     // 1. Build merged DAG
@@ -1820,9 +2157,21 @@ static std::vector<optimize_result> run_native(merge& m, args const& a) {
             .parsimony_score = min_score,
             .radii = std::move(radii_results),
         });
+        std::size_t completed = iter + 1;
+        if (a.checkpoint_after && completed % *a.checkpoint_after == 0) {
+          write_full_checkpoint(m, a, completed, false, rng, patience, results);
+        }
         if (patience(min_score)) {
-          if (a.drift && drift_escape(m, a, prog)) {
-            patience.reset();
+          if (a.drift) {
+            if (a.checkpoint_after) {
+              write_full_checkpoint(m, a, completed, true, rng, patience,
+                                    results);
+            }
+            if (drift_escape(m, a, prog)) {
+              patience.reset();
+            } else {
+              return results;
+            }
           } else {
             return results;
           }
@@ -1990,9 +2339,20 @@ static std::vector<optimize_result> run_native(merge& m, args const& a) {
         .parsimony_score = min_score,
         .radii = std::move(radii_results),
     });
+    std::size_t completed = iter + 1;
+    if (a.checkpoint_after && completed % *a.checkpoint_after == 0) {
+      write_full_checkpoint(m, a, completed, false, rng, patience, results);
+    }
     if (patience(min_score)) {
-      if (a.drift && drift_escape(m, a, prog)) {
-        patience.reset();
+      if (a.drift) {
+        if (a.checkpoint_after) {
+          write_full_checkpoint(m, a, completed, true, rng, patience, results);
+        }
+        if (drift_escape(m, a, prog)) {
+          patience.reset();
+        } else {
+          return results;
+        }
       } else {
         return results;
       }
@@ -2006,15 +2366,25 @@ static std::vector<optimize_result> run_native(merge& m, args const& a) {
 // Random optimizer loop with progress
 // ---------------------------------------------------------------------------
 
-static std::vector<optimize_result> run_random(merge& m, args const& a) {
-  std::mt19937 rng(a.seed.value_or(std::random_device{}()));
+static std::vector<optimize_result> run_random(
+    merge& m, args const& a,
+    std::optional<resume_state> resume = std::nullopt) {
+  std::mt19937 rng = resume ? std::move(resume->rng)
+                            : std::mt19937{a.seed.value_or(
+                                  std::random_device{}())};
   random_spr_strategy strategy{};
   std::vector<optimize_result> results;
   results.reserve(a.iterations);
-  progress prog;
+  std::size_t start_iter = 0;
   patience_checker patience{a.patience};
+  if (resume) {
+    results = std::move(resume->results);
+    start_iter = resume->next_iteration;
+    patience = std::move(resume->patience);
+  }
+  progress prog;
 
-  for (std::size_t iter = 0; iter < a.iterations; ++iter) {
+  for (std::size_t iter = start_iter; iter < a.iterations; ++iter) {
     std::cerr << "Iteration " << (iter + 1) << "/" << a.iterations << ":\n";
 
     prog.phase("Building merged DAG");
@@ -2068,6 +2438,10 @@ static std::vector<optimize_result> run_random(merge& m, args const& a) {
         .trees_merged = new_trees.size(),
         .parsimony_score = min_score,
     });
+    std::size_t completed = iter + 1;
+    if (a.checkpoint_after && completed % *a.checkpoint_after == 0) {
+      write_full_checkpoint(m, a, completed, false, rng, patience, results);
+    }
     if (patience(min_score)) return results;
   }
 
@@ -2081,9 +2455,74 @@ static std::vector<optimize_result> run_random(merge& m, args const& a) {
 int main(int argc, char** argv) {
   auto a = parse_args(argc, argv);
 
+  // Derive checkpoint prefix from --output if not explicitly provided.
+  if (a.checkpoint_after && a.checkpoint_prefix.empty()) {
+    a.checkpoint_prefix = strip_pb_suffix(a.output);
+  }
+
   // ---- Load input ----
   phylo_dag dag;
-  if (!a.dag_pb.empty()) {
+  std::optional<resume_state> resume;
+  if (!a.resume.empty()) {
+    auto bytes = larch::read_checkpoint_bytes(a.resume);
+    std::span<const uint8_t> span{
+        reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size()};
+    if (larch::looks_like_checkpoint(span)) {
+      auto ckpt = larch::load_checkpoint_from_bytes(span);
+      if (ckpt.schema_version > larch::checkpoint_schema_version) {
+        std::cerr << "error: checkpoint schema_version " << ckpt.schema_version
+                  << " is newer than this binary supports (max="
+                  << larch::checkpoint_schema_version << ")\n";
+        return 1;
+      }
+      // Args fingerprint check: refuse to resume if any fingerprinted arg
+      // changed. On mismatch, diff the JSON payloads to name the conflicting
+      // fields.
+      std::string runtime_payload = args_fingerprint_payload(a);
+      std::string runtime_digest = larch::sha256_hex(runtime_payload);
+      if (runtime_digest != ckpt.args_fingerprint) {
+        std::cerr << "error: --resume args mismatch (fingerprint differs)\n";
+        auto ckpt_args = parse_args_payload(ckpt.args_payload);
+        auto run_args = parse_args_payload(runtime_payload);
+        for (auto const& [k, v] : run_args) {
+          auto it = ckpt_args.find(k);
+          if (it == ckpt_args.end() || it->second != v) {
+            std::cerr << "  conflicting field: " << k
+                      << " (checkpoint=" << (it == ckpt_args.end() ? "<missing>" : it->second)
+                      << ", runtime=" << v << ")\n";
+          }
+        }
+        return 1;
+      }
+      if (a.optimizer != ckpt.optimizer) {
+        std::cerr << "error: --resume cannot switch optimizer (checkpoint='"
+                  << ckpt.optimizer << "', runtime='" << a.optimizer << "')\n";
+        return 1;
+      }
+      std::cerr << "Resuming from checkpoint " << a.resume
+                << " at iteration " << ckpt.next_iteration << "\n";
+      if (!ckpt.larch2_git_sha.empty() &&
+          ckpt.larch2_git_sha != larch::git_commit) {
+        std::cerr << "  warning: checkpoint built from larch2 commit "
+                  << ckpt.larch2_git_sha << ", current binary is "
+                  << larch::git_commit << "\n";
+      }
+      // Build phylo_dag from the checkpoint's nested dag_data.
+      larch::dag_data_meta meta{
+          .node_names = std::move(ckpt.dag.node_names),
+          .reference_id = std::move(ckpt.dag.reference_id),
+          .reference_seq = std::move(ckpt.dag.reference_seq),
+      };
+      dag = larch::build_phylo_dag_from_proto(std::move(ckpt.dag.edges),
+                                              std::move(meta));
+      resume = resume_state_from_msg(ckpt);
+    } else {
+      // Phase 1 / legacy raw-DAG checkpoint: equivalent to --dag-pb.
+      std::cerr << "Resuming from DAG-only checkpoint " << a.resume
+                << " (no iteration/RNG state recovered)\n";
+      dag = load_proto_dag(a.resume);
+    }
+  } else if (!a.dag_pb.empty()) {
     std::cerr << "Loading DAG from " << a.dag_pb << "...\n";
     dag = load_proto_dag(a.dag_pb);
   } else if (!a.tree_pb.empty()) {
@@ -2116,7 +2555,9 @@ int main(int argc, char** argv) {
     std::cerr << "Building DAG from FASTA + Newick...\n";
     dag = build_from_fasta_newick(a.fasta, a.newick, a.refseq);
   } else {
-    std::cerr << "error: one of --dag-pb, --tree-pb, or --fasta is required\n";
+    std::cerr
+        << "error: one of --dag-pb, --tree-pb, --fasta, or --resume is "
+           "required\n";
     usage();
     return 1;
   }
@@ -2144,9 +2585,9 @@ int main(int argc, char** argv) {
   std::vector<optimize_result> results;
 
   if (a.optimizer == "native") {
-    results = run_native(m, a);
+    results = run_native(m, a, std::move(resume));
   } else if (a.optimizer == "random") {
-    results = run_random(m, a);
+    results = run_random(m, a, std::move(resume));
   } else {
     std::cerr << "error: unknown optimizer '" << a.optimizer
               << "' (expected 'native' or 'random')\n";

--- a/tools/larch2.cpp
+++ b/tools/larch2.cpp
@@ -1854,13 +1854,13 @@ static resume_state resume_state_from_msg(larch::larch_checkpoint_msg const& c) 
 }
 
 static larch::larch_checkpoint_msg build_checkpoint_msg(
-    merge& m, args const& a, std::size_t completed_iter,
+    merge& m, args const& a, std::size_t next_iteration,
     std::mt19937 const& rng, patience_checker const& patience,
     std::vector<optimize_result> const& results) {
   larch::larch_checkpoint_msg c{};
   c.schema_version = larch::checkpoint_schema_version;
   c.larch2_git_sha = larch::git_commit;
-  c.next_iteration = static_cast<int64_t>(completed_iter);
+  c.next_iteration = static_cast<int64_t>(next_iteration);
   c.optimizer = a.optimizer;
   if (a.patience) c.patience.limit = static_cast<int64_t>(*a.patience);
   c.patience.count = static_cast<int64_t>(patience.count);
@@ -1889,58 +1889,7 @@ static larch::larch_checkpoint_msg build_checkpoint_msg(
     c.results.push_back(std::move(m_r));
   }
 
-  // Serialize the merged DAG into the checkpoint's nested dag_data field.
-  // We mirror save_proto_dag's logic, but build a dag_data struct directly
-  // instead of writing it to a file.
-  auto& dag = m.get_result();
-  larch::dag_data& data = c.dag;
-  data.reference_seq = get_reference_sequence(dag);
-
-  std::unordered_map<std::size_t, int64_t> node_to_proto;
-  auto root_idx = get_root_idx(dag);
-  node_to_proto[root_idx] = 0;
-  int64_t next_id = 1;
-  for (auto nv : dag.get_all_nodes()) {
-    auto idx = std::visit([](auto n) { return n.index(); }, nv);
-    if (idx == root_idx) continue;
-    node_to_proto[idx] = next_id++;
-  }
-
-  int64_t edge_id = 0;
-  for (auto ev : dag.get_all_edges()) {
-    std::visit(
-        [&](auto edge) {
-          auto parent_idx =
-              std::visit([](auto n) { return n.index(); }, edge.get_parent());
-          auto child_idx =
-              std::visit([](auto n) { return n.index(); }, edge.get_child());
-          larch::dag_edge de;
-          de.edge_id = edge_id++;
-          de.parent_node = node_to_proto[parent_idx];
-          de.child_node = node_to_proto[child_idx];
-          de.parent_clade = static_cast<int64_t>(edge.clade_index());
-          for (auto& [pos, nucs] : edge.mutations()) {
-            larch::dag_mut dm;
-            dm.position = static_cast<int32_t>(pos);
-            dm.par_nuc = static_cast<int32_t>(nucs.first.raw());
-            dm.mut_nuc = {static_cast<int32_t>(nucs.second.raw())};
-            de.edge_mutations.push_back(std::move(dm));
-          }
-          data.edges.push_back(std::move(de));
-        },
-        ev);
-  }
-  for (auto nv : dag.get_all_nodes()) {
-    std::visit(
-        [&](auto node) {
-          larch::dag_node_name nn;
-          nn.node_id = node_to_proto[node.index()];
-          if constexpr (requires { node.sample_id(); })
-            nn.condensed_leaves = {node.sample_id()};
-          data.node_names.push_back(std::move(nn));
-        },
-        nv);
-  }
+  c.dag = larch::encode_dag_to_proto(m.get_result());
 
   c.args_payload = args_fingerprint_payload(a);
   c.args_fingerprint = larch::sha256_hex(c.args_payload);
@@ -2507,7 +2456,11 @@ int main(int argc, char** argv) {
                   << ckpt.larch2_git_sha << ", current binary is "
                   << larch::git_commit << "\n";
       }
-      // Build phylo_dag from the checkpoint's nested dag_data.
+      // Pull non-dag fields out before consuming the dag — resume_state_
+      // from_msg reads ckpt.{patience, main_rng, results, next_iteration},
+      // so building it first keeps ckpt fully valid until those fields are
+      // copied.
+      resume = resume_state_from_msg(ckpt);
       larch::dag_data_meta meta{
           .node_names = std::move(ckpt.dag.node_names),
           .reference_id = std::move(ckpt.dag.reference_id),
@@ -2515,7 +2468,6 @@ int main(int argc, char** argv) {
       };
       dag = larch::build_phylo_dag_from_proto(std::move(ckpt.dag.edges),
                                               std::move(meta));
-      resume = resume_state_from_msg(ckpt);
     } else {
       // Phase 1 / legacy raw-DAG checkpoint: equivalent to --dag-pb.
       std::cerr << "Resuming from DAG-only checkpoint " << a.resume

--- a/tools/larch2.cpp
+++ b/tools/larch2.cpp
@@ -1709,13 +1709,7 @@ static bool drift_escape(merge& m, args const& a, progress& prog) {
 // args_fingerprint and also stored verbatim alongside the digest so a
 // mismatch on resume can name the differing fields.
 static std::string args_fingerprint_payload(args const& a) {
-  auto opt_u = [](std::optional<std::uint32_t> const& v) {
-    return v ? std::to_string(*v) : std::string{"null"};
-  };
-  auto opt_z = [](std::optional<std::size_t> const& v) {
-    return v ? std::to_string(*v) : std::string{"null"};
-  };
-  auto opt_i = [](std::optional<int> const& v) {
+  auto opt = [](auto const& v) {
     return v ? std::to_string(*v) : std::string{"null"};
   };
   auto j_bool = [](bool b) { return b ? "true" : "false"; };
@@ -1739,29 +1733,29 @@ static std::string args_fingerprint_payload(args const& a) {
   os << "\"iterations\":" << a.iterations;
   os << ",\"optimizer\":" << j_str(a.optimizer);
   os << ",\"max_moves\":" << a.max_moves;
-  os << ",\"seed\":" << opt_u(a.seed);
+  os << ",\"seed\":" << opt(a.seed);
   os << ",\"sample_method\":" << j_str(a.sample_method);
   os << ",\"sample_uniformly\":" << j_bool(a.sample_uniformly);
   os << ",\"sample_per_radius\":" << j_bool(a.sample_per_radius);
   os << ",\"ignore_root_edge_mutations\":"
      << j_bool(a.ignore_root_edge_mutations);
   os << ",\"callback_option\":" << j_str(a.callback_option);
-  os << ",\"switch_subtrees\":" << opt_z(a.switch_subtrees);
+  os << ",\"switch_subtrees\":" << opt(a.switch_subtrees);
   os << ",\"min_subtree_clade_size\":" << a.min_subtree_clade_size;
   os << ",\"max_subtree_clade_size\":" << a.max_subtree_clade_size;
   os << ",\"move_coeff_pscore\":" << a.move_coeff_pscore;
   os << ",\"move_coeff_nodes\":" << a.move_coeff_nodes;
-  os << ",\"move_score_threshold\":" << opt_i(a.move_score_threshold);
-  os << ",\"patience\":" << opt_z(a.patience);
-  os << ",\"drift\":" << opt_z(a.drift);
+  os << ",\"move_score_threshold\":" << opt(a.move_score_threshold);
+  os << ",\"patience\":" << opt(a.patience);
+  os << ",\"drift\":" << opt(a.drift);
   os << ",\"inplace_steps\":" << a.inplace_steps;
   os << ",\"inplace_threshold\":" << a.inplace_threshold;
-  os << ",\"inplace_budget\":" << opt_i(a.inplace_budget);
+  os << ",\"inplace_budget\":" << opt(a.inplace_budget);
   os << ",\"inplace_temperature\":" << a.inplace_temperature;
   os << ",\"inplace_cooling\":" << a.inplace_cooling;
   os << ",\"inplace_fragments\":" << j_str(frag_to_str(a.inplace_fragments));
   os << ",\"drift_mode\":" << j_str(drift_to_str(a.drift_mode));
-  os << ",\"drift_seed\":" << opt_u(a.drift_seed);
+  os << ",\"drift_seed\":" << opt(a.drift_seed);
   os << "}";
   return os.str();
 }
@@ -1871,7 +1865,7 @@ static larch::larch_checkpoint_msg build_checkpoint_msg(
   // captured (no in-progress drift state at our checkpoint sites).
   c.results.reserve(results.size());
   for (auto const& r : results) {
-    larch::optimize_result_msg_pb m_r{};
+    larch::optimize_result_msg m_r{};
     m_r.iteration = static_cast<int64_t>(r.iteration);
     m_r.dag_node_count = static_cast<int64_t>(r.dag_node_count);
     m_r.dag_edge_count = static_cast<int64_t>(r.dag_edge_count);
@@ -1879,7 +1873,7 @@ static larch::larch_checkpoint_msg build_checkpoint_msg(
     m_r.parsimony_score = static_cast<int64_t>(r.parsimony_score);
     m_r.radii.reserve(r.radii.size());
     for (auto const& rd : r.radii) {
-      larch::radius_result_msg_pb m_rd{};
+      larch::radius_result_msg m_rd{};
       m_rd.radius = static_cast<int64_t>(rd.radius);
       m_rd.moves_found = static_cast<int64_t>(rd.moves_found);
       m_rd.moves_applied = static_cast<int64_t>(rd.moves_applied);


### PR DESCRIPTION
Closes #39

## Summary
- New CLI flags `--checkpoint-after <N>`, `--checkpoint-prefix <P>`, and `--resume <path>` add configurable checkpoint/resume to the larch2 optimization loop.
- Phased per the issue: **Phase 1** writes DAG-only checkpoints (`--resume` is functionally equivalent to `--dag-pb`); **Phase 2** writes a full-state `larch_checkpoint` (DAG + RNG + patience + results + git SHA + args fingerprint) so a resumed run is canonical-equivalent to an uninterrupted run with the same seeds.
- Args fingerprint is SHA-256 over a JSON payload of the trajectory-affecting flags. The payload itself is also stored alongside the digest so a mismatch on resume names the conflicting field. Resume rejects every input flag (`--dag-pb`, `--tree-pb`, `--fasta`, `--newick`, `--refseq`, `--vcf`) since the checkpoint is self-describing.

## Implementation notes
- `proto/checkpoint.proto` + `include/larch/checkpoint.hpp` define the `larch_checkpoint` message family. C++ proto-mirror structs use the existing reflection-based encoder, plus new `std::optional<int64_t>` overloads so `optional uint64` fields distinguish `0` from "unset".
- mt19937 (de)serialization uses `std::ostringstream` / `operator<<` (the C++ standard guarantees byte-exact round-trip).
- SHA-256 is a self-contained FIPS 180-4 implementation in `src/checkpoint.cpp` (no new dep).
- Atomic write: `<path>.tmp` then `rename`.
- Format detection: a `larch_checkpoint` always starts with the byte `0x08` (tag for `schema_version`, varint), distinguishing it from raw `dag_data` files (`0x0a` or other length-delimited fields).
- Determinism fix to `build_phylo_dag_from_proto`: walk proto IDs in sorted order and append edges in `edge_id` order so a save+load round trip preserves the in-memory `phylo_dag`'s node/edge layout. The previous unordered_map iteration and parent-sort silently broke determinism for resume because sampling traverses the DAG by node-index and children-list order.

## Tests added
- `test/checkpoint_test.cpp` — mt19937 round-trip, `larch_checkpoint` proto round-trip (incl. nested `dag_data`, results vector, patience state, RNG state), SHA-256 known-answer tests, `optional<int64_t>` zero-vs-absent presence semantics.
- `test/checkpoint_integration.sh` — end-to-end CLI: Phase 2 deterministic resume for K∈{1,2,3} with canonical-equal final output; multi-resume chain (catches RNG-state non-idempotency); Phase 1 score-not-worse-than-baseline; args fingerprint mismatch refused with the conflicting field named; `--resume` + `--vcf` refused; pre-drift checkpoint emission with `--patience 2 --drift 1`; future `schema_version` rejected with a clear error.
- `test/dag_canonical_equal.cpp` — content-keyed canonical comparison helper used by the integration test (uses `sample_id` for leaves and the compact-genome string for inner nodes; edge tuples as a multiset). Stronger than the issue's suggested proto-id sort, which would fail when merge state differs across runs and reorders proto-id assignments even though the DAGs are logically equivalent.

## Test plan
- [x] `ctest --test-dir build` — all 21 tests pass (19 existing + 2 new).
- [x] Manual verification: 6-iter run with `--checkpoint-after 1` writes `out.ckpt-{1..6}.pb.gz` and the final output canonical-equals a baseline uninterrupted run for every checkpoint K.
- [x] Pre-drift checkpoint manually verified with `--patience 2 --drift 1` on `data/testcase/full_dag.pb.gz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)